### PR TITLE
bump to 0.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_docs_as_code",
-    version = "0.1.1",
+    version = "0.2.0",
     compatibility_level = 0,
 )
 


### PR DESCRIPTION
The 0.1.1 release was labeled 0.1.0 by accident. In order to make a clean release we need a new version. Sounds like a good time to bump the minor version to clearly indicate that 0.1.x is broken.