### PR TITLE
docs-as-code: Add CICD workflow to the repository

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -1,0 +1,42 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: "Gitlint Action"
+description: "An action to install and run Gitlint on PR commits"
+inputs:
+  pr-number:
+    description: "Pull Request number used to fetch commits"
+    required: true
+  base-branch:
+    description: "Base branch to compare commits against (default: main)"
+    default: "main"
+    required: false
+runs:
+  using: "docker"
+  image: "jorisroovers/gitlint:0.19.1"
+  entrypoint: /bin/sh
+  args:
+    - -c
+    - |
+      git config --global --add safe.directory /github/workspace && \
+      git fetch origin +refs/heads/${{ inputs.base-branch }}:refs/remotes/origin/${{ inputs.base-branch }} && \
+      git fetch origin +refs/pull/${{ inputs.pr-number }}/head && \
+      if ! gitlint --commits origin/${{ inputs.base-branch }}..HEAD; then \
+        echo -e "\nWARNING: Your commit message does not follow the required format." && \
+        echo "Formatting rules: https://eclipse-score.github.io/score/main/contribute/general/git.html" && \
+        echo -e "To fix your commit message, run:\n" && \
+        echo " git commit --amend" && \
+        echo "Then update your commit (fix gitlint warnings). Finally, force-push:" && \
+        echo " git push --force-with-lease" && \
+        exit 1; \
+      fi

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Copyright checks
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+jobs:
+  copyright-check:
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main
+    with:
+      bazel-target: "run //:copyright.check"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,30 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Formatting checks
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+jobs:
+  formatting-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.9.1
+      - name: Run formatting checks
+        run: |
+          bazel test //src:format.check

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: License check preparation
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+
+jobs:
+  license-check:
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@main
+    with:
+      repo-url: "${{ github.server_url }}/${{ github.repository }}"
+    secrets:
+      dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Run Bazel Tests
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+      - name: Run test targets
+        run: |
+          bazel test ...


### PR DESCRIPTION
Add copyright, format, gitlint, licence_check and test workflows to the cicd of the repository.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com