### PR TITLE
Fixing bug that broke 'docs_needs'

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,4 +27,5 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.9.1
       - name: Run formatting checks
         run: |
+          bazel run //src:ide_support
           bazel test //src:format.check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,5 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Run test targets
         run: |
+          bazel run //src:ide_support
           bazel test ...

--- a/docs.bzl
+++ b/docs.bzl
@@ -38,11 +38,11 @@
 # For user-facing documentation, refer to `/README.md`.
 
 load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library")
-load("@score_docs_as_code//src/extensions/score_source_code_linker:collect_source_files.bzl", "parse_source_files_for_needs_links")
 load("@pip_process//:requirements.bzl", "all_requirements", "requirement")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 load("@rules_python//sphinxdocs:sphinx_docs_library.bzl", "sphinx_docs_library")
+load("@score_docs_as_code//src/extensions/score_source_code_linker:collect_source_files.bzl", "parse_source_files_for_needs_links")
 load("@score_python_basics//:defs.bzl", "score_virtualenv")
 
 sphinx_requirements = all_requirements + [
@@ -158,7 +158,7 @@ def _ide_support():
         reqs = sphinx_requirements,
     )
 
-def _docs(name = "docs", format = "html", external_needs_deps = list(), external_needs_def = dict()):
+def _docs(name = "docs", format = "html", external_needs_deps = list(), external_needs_def = list()):
     ext_needs_arg = "--define=external_needs_source=" + json.encode(external_needs_def)
 
     sphinx_docs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This file is at the root level, as it applies to all Python code,
 # not only to docs or to tools.
 [tool.pyright]
-extends = "bazel-bin/examples/simple/ide_support.runfiles/score_python_basics~/pyproject.toml"
+extends = "bazel-bin/src/ide_support.runfiles/score_python_basics~/pyproject.toml"
 
 exclude = [
     "**/__pycache__",
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [tool.ruff]
-extend = "bazel-bin/examples/simple/ide_support.runfiles/score_python_basics~/pyproject.toml"
+extend = "bazel-bin/src/ide_support.runfiles/score_python_basics~/pyproject.toml"
 
 extend-exclude = [
     "**/__pycache__",

--- a/src/BUILD
+++ b/src/BUILD
@@ -10,7 +10,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun", "format_test")
 load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library")
 load("@pip_process//:requirements.bzl", "all_requirements", "requirement")
@@ -19,7 +18,20 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary")
 load("@score_dash_license_checker//:dash.bzl", "dash_license_checker")
+load("@score_python_basics//:defs.bzl", "score_virtualenv")
 
+score_virtualenv(
+    reqs = [
+        "@score_docs_as_code//src:plantuml_for_python",
+        "@score_docs_as_code//src/extensions:score_plantuml",
+        "@score_docs_as_code//src/find_runfiles:find_runfiles",
+        "@score_docs_as_code//src/extensions/score_draw_uml_funcs:score_draw_uml_funcs",
+        "@score_docs_as_code//src/extensions/score_header_service:score_header_service",
+        "@score_docs_as_code//src/extensions/score_layout:score_layout",
+        "@score_docs_as_code//src/extensions/score_metamodel:score_metamodel",
+        "@score_docs_as_code//src/extensions/score_source_code_linker:score_source_code_linker",
+    ],
+)
 # These are only exported because they're passed as files to the //docs.bzl
 # macros, and thus must be visible to other packages. They should only be
 # referenced by the //docs.bzl macros.
@@ -135,7 +147,7 @@ filegroup(
 
 dash_license_checker(
     src = ":requirements_lock",
-    file_type = "requirements",  # let it auto-detect based on project_config
+    file_type = "requirements",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
The 'dict' default value broken the parsing we had inside 'metamodel/__init__.py' to parse that value when  docs_needs  was build. 

This changes the default value to the expected one (list). 