### PR TITLE
Fixed wrong check activation

### DIFF
--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -25,12 +25,35 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     the requirement id or not.
     ---
     """
+    # These folders are taken from 'https://github.com/eclipse-score/process_description/tree/main/process'
+    # This means, any needs within any of these folders (no matter where they are) will not be required to have 3 parts
+    process_folder_names = [
+        "general_concepts",
+        "introduction",
+        "process_areas",
+        "roles",
+        "standards",
+        "workflows",
+        "workproducts",
+        "process",
+    ]
     # Split the string by underscores
     parts = need["id"].split("__")
-
-    if need["id"].startswith(
-        ("gd_", "wf__", "wp__", "rl__", "stkh_req__", "tool_req__", "doc__")
-    ) or ("process/" in str(need.get("docname", ""))):
+    if need["type"] in [
+        "std_wp",
+        "document",  # This is used in 'platform_managment' in score.
+        "gd_guidl",
+        "workflow",
+        "gd_chklst",
+        "std_req",
+        "role",
+        "doc_concept",
+        "gd_temp",
+        "gd_method",
+        "gd_req",
+        "workproduct",
+        "doc_getstrt",
+    ] or any(prefix in str(need.get("docname", "")) for prefix in process_folder_names):
         if len(parts) != 2 and len(parts) != 3:
             msg = (
                 "expected to consisting of one of these 2 formats:"
@@ -45,7 +68,6 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
                 "`<Req Type>__<Abbreviations>__<Architectural Element>`."
             )
             log.warning_for_option(need, "id", msg)
-
 
 @local_check
 def check_id_length(app: Sphinx, need: NeedsInfoType, log: CheckLogger):


### PR DESCRIPTION
Check found False positives due to 'process' being moved and loosing it's prefix.


I would like some feedback to this, I don't 100% like the solution as it's a rather specific solution with potentially some unintended side effects, though I couldn't think of anything else currently. 

I did try moving the 'process_description' around so that 'process' is again in the document name, this however proofed to not be working, though I might have screwed this up somehow and not realized.