### PR TITLE
Add bugfix for new module json_encoding quirks

### DIFF
--- a/examples/linking-both/BUILD
+++ b/examples/linking-both/BUILD
@@ -29,7 +29,6 @@ docs(
                 {
                     "base_url": "https://eclipse-score.github.io/score/main",
                     "json_url": "https://eclipse-score.github.io/score/main/needs.json",
-                    "version": "0.1",
                     "id_prefix": "score_",
                 },
             ],
@@ -41,7 +40,6 @@ docs(
                 {
                     "base_url": "https://eclipse-score.github.io/score/main",
                     "json_path": "/score_platform~/docs/docs_needs/_build/needs/needs.json",
-                    "version": "0.1",
                     "id_prefix": "score_",
                 },
             ],

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -266,10 +266,12 @@ def default_options() -> list[str]:
 
 
 def parse_external_needs_sources(app: Sphinx, config):
-    # HACK: mabye there is a nicer way for this
+    # HACK: maybe there is a nicer way for this
     if app.config.external_needs_source not in ["[]", ""]:
         x = None
-        x = json.loads(app.config.external_needs_source)
+        # NOTE: Due to upgrades in modules, encoding changed. Need to clean string in order to read it right again.
+        clean_str = app.config.external_needs_source.replace('\\"', "")
+        x = json.loads(clean_str)
         if r := os.getenv("RUNFILES_DIR"):
             if x[0].get("json_path", None):
                 for a in x:


### PR DESCRIPTION
It seems that through upgrading some of the dependencies, the json_encoding inside bzl files is now different therefore the decoding we did in docs-as-code now doesn't work properly anymore and errors.

This PR fixes this error. Tested via proces repo with local path override. 