### PR TITLE
Integrate renovatebot into docs-as-code

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Run renovate
+
+on:
+  schedule:
+    - cron: "0 19 * * *"  # Every day at 9:00 PM Europe time
+  workflow_dispatch: {}  # Allow manual runs too
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@@v4.2.2
+
+      - name: Run renovate
+        uses: renovatebot/github-action@v42.0.2
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,8 +15,8 @@ name: Run renovate
 
 on:
   schedule:
-    - cron: "0 19 * * *"  # Every day at 9:00 PM Europe time
-  workflow_dispatch: {}  # Allow manual runs too
+    - cron: "0 19 * * *" # Every day at 9:00 PM Europe time
+  workflow_dispatch: {} # Allow manual runs too
 
 jobs:
   renovate:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+    "extends": ["config:base"],
+    "enabledManagers": ["bazel"],
+    "regexManagers": [
+      {
+        "fileMatch": ["^MODULE\\.bazel$"],
+        "matchStrings": [
+          "bazel_dep\\(name\\s*=\\s*\"(?<depName>[^\"]+)\",\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        ],
+        "datasourceTemplate": "github-releases",
+        "versioningTemplate": "semver",
+        "packageNameTemplate": "{{depName}}"
+      }
+    ]
+  }


### PR DESCRIPTION
Integrate RenovateBot inside the CI/CD that will run daily at 9 PM to check if libraries inside Module.bazel are outdated and propose PR to update them .

relates to: [#1004](https://github.com/eclipse-score/score/issues/1004)
