### PR TITLE
Change hover color for visited links in the score grid

### DIFF
--- a/src/assets/css/score_design.css
+++ b/src/assets/css/score_design.css
@@ -5,6 +5,10 @@
     color: #FFFFFF;
 }
 
+.score-grid a:hover:visited {
+    color: #e0e0e0;
+}
+
 .score-grid .sd-card-header  {
     background-color: var(--pst-color-secondary) !important;
     color: var(--pst-color-text-muted);


### PR DESCRIPTION
This sets the color of visited links when hovering them. The current color matches the grid background making the links look disappeared.

![image](https://github.com/user-attachments/assets/572a0429-35a9-4289-a924-ab764407629e)
