### PR TITLE
Bugfix: External needs graph checks & misc fixes

### DIFF
--- a/docs/example/index.rst
+++ b/docs/example/index.rst
@@ -30,7 +30,7 @@ This is a rendered example of the 'examples/linking-both' folder using the `docs
 
    Some content to make sure we also can render this
    This is a link to an external need inside the 'score' documentation.
-   :need:`SCORE_gd_req__req__attr_safety`
+   :need:`SCORE_feat_req__kvs__config_file`. 
    Note how it starts with the defined prefix but in UPPERCASE. This comes from sphinx-needs, `see here <https://github.com/useblocks/sphinx-needs/blob/master/sphinx_needs/external_needs.py#L119>`_
 
 

--- a/docs/example/testing/index.rst
+++ b/docs/example/testing/index.rst
@@ -25,7 +25,7 @@ This example will help catch things and bugs when rst's are defined inside a fol
 
    Some content to make sure we also can render this. 
    This is a link to an external need inside the 'score' documentation.
-   :need:`SCORE_gd_req__req__attr_safety`
+   :need:`SCORE_feat_req__kvs__config_file`. 
    Note how it starts with the defined prefix but in UPPERCASE. This comes from sphinx-needs, `see here <https://github.com/useblocks/sphinx-needs/blob/master/sphinx_needs/external_needs.py#L119>`_
 
 

--- a/examples/linking-both/index.rst
+++ b/examples/linking-both/index.rst
@@ -33,7 +33,7 @@ This is a simple example of a documentation page using the `docs` tool.
 
    Some content to make sure we also can render this
    This is a link to an external need inside the 'score' documentation.
-   :need:`SCORE_gd_req__req__attr_safety`
+   :need:`SCORE_feat_req__kvs__config_file`
    Note how it starts with the defined prefix but in UPPERCASE. This comes from sphinx-needs, `see here <https://github.com/useblocks/sphinx-needs/blob/master/sphinx_needs/external_needs.py#L119>`_
 
 

--- a/examples/linking-both/testing/test.rst
+++ b/examples/linking-both/testing/test.rst
@@ -25,7 +25,7 @@ This example will help catch things and bugs when rst's are defined inside a fol
 
    Some content to make sure we also can render this. 
    This is a link to an external need inside the 'score' documentation.
-   :need:`SCORE_gd_req__req__attr_safety`
+   :need:`SCORE_feat_req__kvs__config_file`. 
    Note how it starts with the defined prefix but in UPPERCASE. This comes from sphinx-needs, `see here <https://github.com/useblocks/sphinx-needs/blob/master/sphinx_needs/external_needs.py#L119>`_
 
 

--- a/examples/linking-latest/index.rst
+++ b/examples/linking-latest/index.rst
@@ -25,6 +25,6 @@ This is a simple example of a documentation page using the `docs` tool.
 
    Some content to make sure we also can render this
    This is a link to an external need inside the 'score' documentation.
-   :need:`SCORE_gd_req__req__attr_safety`. 
+   :need:`SCORE_feat_req__kvs__config_file`. 
    Note how it starts with the defined prefix but in UPPERCASE. This comes from sphinx-needs, `see here <https://github.com/useblocks/sphinx-needs/blob/master/sphinx_needs/external_needs.py#L119>`_
 

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -187,9 +187,9 @@ needs_types:
       security: "^(YES|NO)$"
       realizes: "^wp__.+$"
   # The following 3 guidance requirements enforce the requirement structure and attributes:
-  # req-Id: gd_req__req__structure
-  # req-Id: gd_req__requirements_attr_description
-  # req-Id: gd_req__req__linkage
+  # req- Id: gd_req__req__structure
+  # req- Id: gd_req__requirements_attr_description
+  # req- Id: gd_req__req__linkage
   # Requirements
   stkh_req:
     title: "Stakeholder Requirement"
@@ -219,7 +219,7 @@ needs_types:
       safety: "^(QM|ASIL_B|ASIL_D)$"
       status: "^(valid|invalid)$"
     mandatory_links:
-      # req-Id: gd_req__req__linkage_fulfill
+      # req- Id: gd_req__req__linkage_fulfill
       satisfies: "^stkh_req__.*$"
     optional_options:
       codelink: "^.*$"
@@ -560,10 +560,10 @@ needs_extra_links:
 #   - condition: defines the condition that should be checked
 #     - [and / or / xor / not]
 ##############################################################
-# req-Id: gd_req__req__linkage_architecture
-# req-Id: gd_req__req__linkage_safety
+# req- Id: gd_req__req__linkage_architecture
+# req- Id: gd_req__req__linkage_safety
 graph_checks:
-  # req-Id: gd_req__req__linkage_safety
+  # req- Id: gd_req__req__linkage_safety
   req_safety_linkage:
     needs:
       include: "comp_req, feat_req"
@@ -582,7 +582,7 @@ graph_checks:
       condition: "status == valid"
     check:
       satisfies: "status == valid"
-  # req-Id: gd_req__req__linkage_architecture
+  # req- Id: gd_req__req__linkage_architecture
   arch_safety_linkage:
     needs:
       include: "comp_req, feat_req"

--- a/src/extensions/score_metamodel/tests/test_rules_file_based.py
+++ b/src/extensions/score_metamodel/tests/test_rules_file_based.py
@@ -175,7 +175,7 @@ def test_rst_files(
             "Unable to extract test data from the rst file: "
             f"{rst_file}. Please check the file for the correct format."
         )
-    print(f"RST Data: {rst_data}")
+    # print(f"RST Data: {rst_data}")
     app: SphinxTestApp = sphinx_app_setup(RST_DIR / rst_file)
     os.chdir(app.srcdir)  # Change working directory to the source directory
 
@@ -185,7 +185,7 @@ def test_rst_files(
 
     # Collect the warnings
     warnings = app.warning.getvalue().splitlines()
-    print(f"Warnings: {warnings}")
+    # print(f"Warnings: {warnings}")
 
     # Check if the expected warnings are present
     for warning_info in rst_data.warning_infos:


### PR DESCRIPTION
Our checks have filtered out 'external needs' completely, this lead to a bug that if a local need referenced an external need & that local need should be checked via a graph check, it will not find the linked need to check, as it is external and filtered. 

This PR addresses this bug behavior. 


--- 

PR addresses: 

- Graph checks now work correctly with local needs that link to external needs => changed behavior of filtering
- Source code linker not finding things => broke template strings until we have tool requirements.
- Print statements in tests were left uncommented  => commented them out
- Fixing links that no longer are in SCORE => change the linked need

fixes: #77 