### PR TITLE
Add support to inject other pip index

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,6 +48,8 @@ use_repo(python)
 ###############################################################################
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
+    envsubst = ["PIP_INDEX_URL"],
+    extra_pip_args = ["--index-url=${PIP_INDEX_URL:-https://pypi.org/simple/}"],
     hub_name = "pip_process",
     python_version = PYTHON_VERSION,
     requirements_lock = "//src:requirements.txt",


### PR DESCRIPTION
Prior to this change, python dependencies were only downloaded from the index
defined in requirements.txt. This is a limitation of rules_py, which usually uses
the bazel downloader for python dependencies. However, if a locked
requirements.txt is provided, it directly uses pip to download patches
from the index specified in the file.

Allow specifying custom index URLs through an environment variable.