### PR TITLE
update process requirements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
   "python.testing.pytestArgs": [
     ".",
     "--ignore-glob=bazel-*/*",
-    "--ignore-glob=.venv_docs/*",
+    "--ignore-glob=.venv*/*",
     "--ignore-glob=_build/*"
   ],
   "python.testing.unittestEnabled": false,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,4 +97,4 @@ bazel_dep(name = "score_cr_checker", version = "0.2.2")
 
 # Grab dash
 bazel_dep(name = "score_dash_license_checker", version = "0.1.1")
-bazel_dep(name = "score_process", version = "1.0.1")
+bazel_dep(name = "score_process", version = "1.0.2")

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -9,6 +9,12 @@ Requirements (Process Compliance)
 
 This section provides an overview of current process requirements and their clarification & implementation status.
 
+.. note::
+  All open issues and pull requests in the process repository are considered as if they
+  are already part of the process requirements. They address a lot of the
+  requirements that are referenced in this document, so we would be blocked if we would
+  not consider them as part of the process requirements.
+
 .. needbar:: Docs-As-Code Requirements Status
   :stacked:
   :show_sum:
@@ -20,16 +26,15 @@ This section provides an overview of current process requirements and their clar
   :xlabels_rotation: 45
   :horizontal:
 
-                   , implemented                                    , partially / not quite clear                                          , not implemented / not clear
-  Common, 'tool_req__docs' in id and implemented == "YES" and "Common Attributes" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Common Attributes" in tags, 'tool_req__docs' in id and implemented == "NO" and "Common Attributes" in tags
-  Doc, 'tool_req__docs' in id and implemented == "YES" and "Documents" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Documents" in tags, 'tool_req__docs' in id and implemented == "NO" and "Documents" in tags
-  Req, 'tool_req__docs' in id and implemented == "YES" and "Requirements" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Requirements" in tags, 'tool_req__docs' in id and implemented == "NO" and "Requirements" in tags
-  Arch, 'tool_req__docs' in id and implemented == "YES" and "Architecture" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Architecture" in tags, 'tool_req__docs' in id and implemented == "NO" and "Architecture" in tags
-  DDesign, 'tool_req__docs' in id and implemented == "YES" and "Detailed Design & Code" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Detailed Design & Code" in tags, 'tool_req__docs' in id and implemented == "NO" and "Detailed Design & Code" in tags
-  TVR, 'tool_req__docs' in id and implemented == "YES" and "Tool Verification Reports" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Tool Verification Reports" in tags, 'tool_req__docs' in id and implemented == "NO" and "Tool Verification Reports" in tags
-  Other, 'tool_req__docs' in id and implemented == "YES" and "Process / Other" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Process / Other" in tags, 'tool_req__docs' in id and implemented == "NO" and "Process / Other" in tags
-  SftyAn, 'tool_req__docs' in id and implemented == "YES" and "Safety Analysis" in tags, 'tool_req__docs' in id and implemented == "PARTIAL" and "Safety Analysis" in tags, 'tool_req__docs' in id and implemented == "NO" and "Safety Analysis" in tags
-
+                   , implemented                                    , partially implemented                                          , not implemented, process not clear
+  Common,  'tool_req__docs' in id and implemented == "YES" and "Common Attributes"         in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Common Attributes"         in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and         "Common Attributes" in tags and status == "valid", 'tool_req__docs' in id and         "Common Attributes" in tags and status != "valid"
+  Doc,     'tool_req__docs' in id and implemented == "YES" and "Documents"                 in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Documents"                 in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and                 "Documents" in tags and status == "valid", 'tool_req__docs' in id and                 "Documents" in tags and status != "valid"
+  Req,     'tool_req__docs' in id and implemented == "YES" and "Requirements"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Requirements"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and              "Requirements" in tags and status == "valid", 'tool_req__docs' in id and              "Requirements" in tags and status != "valid"
+  Arch,    'tool_req__docs' in id and implemented == "YES" and "Architecture"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Architecture"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and              "Architecture" in tags and status == "valid", 'tool_req__docs' in id and              "Architecture" in tags and status != "valid"
+  DDesign, 'tool_req__docs' in id and implemented == "YES" and "Detailed Design & Code"    in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Detailed Design & Code"    in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and    "Detailed Design & Code" in tags and status == "valid", 'tool_req__docs' in id and    "Detailed Design & Code" in tags and status != "valid"
+  TVR,     'tool_req__docs' in id and implemented == "YES" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and "Tool Verification Reports" in tags and status != "valid"
+  Other,   'tool_req__docs' in id and implemented == "YES" and "Process / Other"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Process / Other"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and           "Process / Other" in tags and status == "valid", 'tool_req__docs' in id and           "Process / Other" in tags and status != "valid"
+  SftyAn,  'tool_req__docs' in id and implemented == "YES" and "Safety Analysis"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Safety Analysis"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and           "Safety Analysis" in tags and status == "valid", 'tool_req__docs' in id and           "Safety Analysis" in tags and status != "valid"
 
 
 🗂️ Common Attributes
@@ -53,7 +58,6 @@ This section provides an overview of current process requirements and their clar
      PROCESS_gd_req__req__attr_uid,
      PROCESS_gd_req__tool__attr_uid,
      PROCESS_gd_req__arch__attribute_uid
-  :parent_has_problem: NO
   :parent_covered: YES: together with tool_req__docs_attr_id_scheme
 
   Docs-as-Code shall enforce that all Need IDs are globally unique across all included
@@ -68,18 +72,14 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :tags: Common Attributes
   :satisfies: PROCESS_gd_req__req__attr_uid, PROCESS_gd_req__arch__attribute_uid
-  :parent_has_problem: YES: Parents are not aligned
   :parent_covered: YES: together with tool_req__docs_attr_id
 
   Docs-as-Code shall enforce that Need IDs follow the following naming scheme:
 
-  .. TODO: is it "indicating" or "perfect match"?
-     e.g. workflow -> wf would be ok for "indicating", but not for "perfect match"
-
   * A prefix indicating the need type (e.g. `feature__`)
-  * A middle part indicating the hierarchical structure of the need:
+  * A middle part matching the hierarchical structure of the need:
      * For requirements: a portion of the feature tree or a component acronym
-     * For architecture elements: the final part of the feature tree
+     * For architecture elements: the structural element (e.g. some part of the feature tree, component acronym)
   * Additional descriptive text to ensure human readability
 
 
@@ -92,7 +92,6 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :tags: Common Attributes
   :satisfies: PROCESS_gd_req__requirements_attr_title
-  :parent_has_problem: NO
   :parent_covered: NO: Can not ensure summary
 
 
@@ -126,7 +125,6 @@ This section provides an overview of current process requirements and their clar
   :satisfies:
      PROCESS_gd_req__requirements_attr_security,
      PROCESS_gd_req__arch_attr_security,
-  :parent_has_problem: YES: Architecture talks about requirements. Parents not aligned.
 
   Docs-as-Code shall enforce that the ``security`` attribute has one of the following values:
 
@@ -136,7 +134,7 @@ This section provides an overview of current process requirements and their clar
   This rule applies to:
 
   * all requirement types defined in :need:`tool_req__docs_req_types`, except process requirements.
-  * all architecture elements (TODO; see https://github.com/eclipse-score/process_description/issues/34)
+  * all architecture elements defined in :need:`tool_req__docs_arch_types`.
 
 
 ---------------------------
@@ -148,7 +146,6 @@ This section provides an overview of current process requirements and their clar
   :tags: Common Attributes
   :implemented: YES
   :parent_covered: YES
-  :parent_has_problem: YES: Architecture talks about requirements. Parents not aligned
   :satisfies:
      PROCESS_gd_req__req__attr_safety,
      PROCESS_gd_req__arch__attr_safety
@@ -162,7 +159,7 @@ This section provides an overview of current process requirements and their clar
   This rule applies to:
 
   * all requirement types defined in :need:`tool_req__docs_req_types`, except process requirements.
-  * all architecture elements (TODO; see https://github.com/eclipse-score/process_description/issues/34)
+  * all architecture elements defined in :need:`tool_req__docs_arch_types`.
 
 ----------
 🚦 Status
@@ -172,7 +169,6 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_common_attr_status
   :tags: Common Attributes
   :implemented: YES
-  :parent_has_problem: YES: Architecture talks about requirements, currently we have valid|draft
   :parent_covered: YES
   :satisfies:
     PROCESS_gd_req__req__attr_status,
@@ -186,7 +182,7 @@ This section provides an overview of current process requirements and their clar
   This rule applies to:
 
   * all requirement types defined in :need:`tool_req__docs_req_types`, except process requirements.
-  * all architecture elements (TODO; see https://github.com/eclipse-score/process_description/issues/34)
+  * all architecture elements defined in :need:`tool_req__docs_arch_types`.
 
 📚 Documents
 #############
@@ -196,12 +192,13 @@ This section provides an overview of current process requirements and their clar
   :tags: Documents
   :implemented: YES
 
+  .. :satisfies: PROCESS_gd_req__doc_types (next process release)
+
   Docs-as-Code shall support the following document types:
 
   * Generic Document (document)
 
 
-.. NOTE: Header_service trigger/working execution is disabled
 .. tool_req:: Mandatory Document attributes
   :id: tool_req__docs_doc_attr
   :tags: Documents
@@ -211,9 +208,9 @@ This section provides an overview of current process requirements and their clar
    PROCESS_gd_req__doc_approver,
    PROCESS_gd_req__doc_reviewer,
   :parent_covered: NO
-  :parent_has_problem: YES: Which need type to use for this?
 
-  Docs-as-Code shall enforce that each document model element has the following attributes:
+  Docs-as-Code shall enforce that each :need:`tool_req__docs_doc_types` has the
+  following attributes:
 
   * author
   * approver
@@ -226,7 +223,7 @@ This section provides an overview of current process requirements and their clar
   :implemented: NO
   :satisfies: PROCESS_gd_req__doc_author
   :parent_covered: YES: Together with tool_req__docs_doc_attr
-  :parent_has_problem: YES: Unclear how the contribution % is counted and how to accumulate %. Committer is a reserved role.
+  :status: invalid
 
   Docs-as-Code shall provide an automatic mechanism to determine document authors.
 
@@ -234,6 +231,9 @@ This section provides an overview of current process requirements and their clar
   document author. Contributors are accumulated over all commits to the file containing
   the document.
 
+  .. note::
+    The requirement is currently invalid as it's currently unclear how the contribution
+    % are counted and how to accumulate %.
 
 .. tool_req:: Document approver is autofilled
   :id: tool_req__docs_doc_attr_approver_autofill
@@ -241,13 +241,11 @@ This section provides an overview of current process requirements and their clar
   :implemented: NO
   :satisfies: PROCESS_gd_req__doc_approver
   :parent_covered: YES: Together with tool_req__docs_doc_attr
-  :parent_has_problem: YES: CODEOWNER is Github specific.
 
   Docs-as-Code shall provide an automatic mechanism to determine the document approver.
 
-  The approver shall be the last approver listed in *CODEOWNERS* of the file containing
-  the document. The determination is based on the last pull request (PR) that modified
-  the relevant file.
+  The approver shall be the approvers listed in *CODEOWNERS* of the last pull request of
+  the file containing the document.
 
 
 .. tool_req:: Document reviewer is autofilled
@@ -256,13 +254,11 @@ This section provides an overview of current process requirements and their clar
   :implemented: NO
   :satisfies: PROCESS_gd_req__doc_reviewer
   :parent_covered: YES: Together with tool_req__docs_doc_attr
-  :parent_has_problem: NO
 
   Docs-as-Code shall provide an automatic mechanism to determine the document reviewers.
 
-  The ``reviewer`` attribute shall include all reviewers who are not listed as
-  approvers. The determination is based on the last pull request (PR) that modified the
-  relevant file.
+  The reviewer shall be the approvers NOT listed in *CODEOWNERS* of the last pull
+  request of the file containing the document.
 
 
 📋 Requirements
@@ -277,7 +273,6 @@ This section provides an overview of current process requirements and their clar
   :tags: Requirements
   :implemented: YES
   :satisfies: PROCESS_gd_req__req__structure
-  :parent_has_problem: NO
   :parent_covered: YES: Together with tool_req__docs_linkage
 
   Docs-as-Code shall support the following requirement types:
@@ -306,11 +301,11 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_req_attr_reqtype
   :tags: Requirements
   :implemented: PARTIAL
-  :parent_has_problem: YES: tool_req shall not have 'reqtype' as discussed. process not excluded!
   :satisfies: PROCESS_gd_req__req__attr_type
 
-  Docs-as-Code shall enforce that each need of type :need:`tool_req__docs_req_types` has
-  a ``reqtype`` attribute with one of the following values:
+  Docs-as-Code shall enforce that each need of type :need:`tool_req__docs_req_types`
+  except process and tool requirements has a ``reqtype`` attribute with one of the
+  following values:
 
   * Functional
   * Interface
@@ -323,7 +318,7 @@ This section provides an overview of current process requirements and their clar
   :tags: Requirements
   :implemented: NO
   :satisfies: PROCESS_gd_req__req__attr_req_cov
-  :parent_has_problem: YES: Not understandable what is required.
+  :status: invalid
 
   .. warning::
      This requirement is not yet specified. The corresponding parent requirement is
@@ -335,12 +330,17 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :parent_covered: YES
   :satisfies: PROCESS_gd_req__req__attr_test_covered
+  :status: invalid
 
   Docs-As-Code shall allow for every need of type :need:`tool_req__docs_req_types` to
   have a ``testcovered`` attribute, which must be one of:
 
   * Yes
   * No
+
+  .. warning::
+     This requirement is not yet specified. The corresponding parent requirement is
+     unclear and must be clarified before a precise tool requirement can be defined.
 
 -------------------------
 🔗 Links
@@ -352,24 +352,23 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :satisfies: PROCESS_gd_req__req__linkage, PROCESS_gd_req__req__traceability
   :parent_covered: YES
-  :parent_has_problem: YES: Mandatory for all needs? Especially some tool_reqs do not have a process requirement.
 
   Docs-as-Code shall enforce that linking between model elements via the ``satisfies``
-  attribute follows defined rules.
+  attribute follows defined rules. Having at least one link is mandatory.
 
   Allowed source and target combinations are defined in the following table:
 
   .. table::
      :widths: auto
 
-     ========================  ===========================
-     Requirement Type           Allowed Link Target
-     ========================  ===========================
-     Feature Requirements       Stakeholder Requirements
-     Component Requirements     Feature Requirements
-     Process Requirements       Workflows
-     Tooling Requirements       Process Requirements
-     ========================  ===========================
+     ================================ ===========================
+     Source Type                      Allowed Link Target
+     ================================ ===========================
+     Feature Requirements             Stakeholder Requirements
+     Component Requirements           Feature Requirements
+     Process Requirements             Workflows
+     Tooling Requirements             Process Requirements
+     ================================ ===========================
 
 🏛️ Architecture
 ################
@@ -387,30 +386,37 @@ This section provides an overview of current process requirements and their clar
      PROCESS_gd_req__arch__build_blocks,
      PROCESS_gd_req__arch__build_blocks_corr
   :implemented: PARTIAL
-  :parent_has_problem: YES: Referenced in https://github.com/eclipse-score/process_description/issues/34
   :parent_covered: NO
   :status: invalid
 
-  .. warning::
-    **OPEN ISSUE** → Architecture types are not yet understood
-    See: https://github.com/eclipse-score/process_description/issues/34
-
-    The list below is tentative at best.
-
   Docs-as-Code shall support the following architecture types:
 
-  * Feature Architecture Static View (feat_arch_static) - does this count as an architecture type, or is it a view?
-  * Feature Architecture Dynamic View (feat_arch_dyn) - the views below have view in their type name!!
-  * Logical Architecture Interfaces (logic_arc_int) - That's a single interface and not "interfaces"? Or is it a view?
-  * Logical Architecture Interface Operation (logic_arc_int_op)
-  * Module Architecture Static View (mod_view_static)
-  * Module Architecture Dynamic View (mod_view_dyn)
+  * Feature (Architecture Element) = Feature Architecture Static View (feat_arch_static)
+  * Feature Architecture Dynamic View (feat_arch_dyn)
+  * Feature: Logical Architecture Interface (incl Logical Interface View) (logic_arc_int)
+  * Feature: Logical Architecture Interface Operation (logic_arc_int_op)
   * Component Architecture Static View (comp_arc_sta)
   * Component Architecture Dynamic View (comp_arc_dyn)
-  * Component Architecture Interfaces (comp_arc_int)
-  * Component Architecture Interface Operation (comp_arc_int_op)
-  * Real interface?? (see gd_req__arch__build_blocks_corr)
-  * Feature Architecture Interface?? (see gd_req__arch__traceability)
+  * Component Architecture Interface = Real Interface (comp_arc_int)
+  * Component Architecture Interface Operation = Real Interface Operation (comp_arc_int_op)
+
+
+.. tool_req::Module Views
+  :id: tool_req__docs_module_views
+  :tags: Architecture
+  :satisfies:
+     PROCESS_gd_req__arch__hierarchical_structure,
+     PROCESS_gd_req__arch__viewpoints,
+     PROCESS_gd_req__arch__build_blocks,
+     PROCESS_gd_req__arch__build_blocks_corr
+  :implemented: PARTIAL
+  :parent_covered: NO
+  :status: invalid
+
+  Docs-as-Code shall support the following module view-types:
+
+  * Module = Module Architecture Static View = Top Level SW component container (mod_view_static)
+  * Module Architecture Dynamic View = Top Level SW component container (mod_view_dyn)
 
 
 ------------------------
@@ -426,7 +432,6 @@ This section provides an overview of current process requirements and their clar
    PROCESS_gd_req__arch__attr_fulfils,
    PROCESS_gd_req__arch__traceability,
   :parent_covered: YES
-  :parent_has_problem: YES: Attribute is not mentioned. Link direction not clear. Fig. 22 does not contain 'fulfils'
 
   Docs-as-Code shall enforce that linking via the ``fulfils`` attribute follows defined rules.
 
@@ -450,7 +455,6 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :satisfies: PROCESS_gd_req__arch__linkage_requirement
   :parent_covered: YES
-  :parent_has_problem: NO
 
   Docs-as-Code shall enforce that architecture model elements of type
   :need:`tool_req__docs_arch_types` with ``safety != QM`` are linked to requirements of
@@ -463,7 +467,6 @@ This section provides an overview of current process requirements and their clar
   :implemented: PARTIAL
   :satisfies: PROCESS_gd_req__arch__linkage_safety_trace
   :parent_covered: NO
-  :parent_has_problem: NO
 
   Docs-as-Code shall enforce that architecture model elements of type
   :need:`tool_req__docs_arch_types` with ``safety != QM`` can only be linked to other
@@ -489,7 +492,6 @@ This section provides an overview of current process requirements and their clar
   :implemented: YES
   :satisfies: PROCESS_doc_concept__arch__process, PROCESS_gd_req__arch__viewpoints
   :parent_covered: YES
-  :parent_has_problem: NO
 
   Docs-as-Code shall enable the rendering of diagrams for the following architecture views:
 
@@ -524,7 +526,6 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_dd_link_testcase
   :tags: Detailed Design & Code
   :implemented: NO
-  :parent_has_problem: YES: Test vs Testcase unclear. Direction unclear. Goal unclear.
   :satisfies: PROCESS_gd_req__req__attr_testlink
 
   Docs-as-Code shall allow requirements of type :need:`tool_req__docs_req_types` to
@@ -551,7 +552,6 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_tvr_safety
   :tags: Tool Verification Reports
   :implemented: NO
-  :parent_has_problem: YES: Safety affected vs Safety relevance
   :parent_covered: YES
   :satisfies: PROCESS_gd_req__tool__attr_safety_affected
 
@@ -566,7 +566,6 @@ This section provides an overview of current process requirements and their clar
   :tags: Tool Verification Reports
   :implemented: NO
   :parent_covered: YES
-  :parent_has_problem: YES: Safety affected vs Safety relevance
   :satisfies: PROCESS_gd_req__tool_attr_security_affected
 
   Docs-as-Code shall enforce that every Tool Verification Report includes a
@@ -580,7 +579,6 @@ This section provides an overview of current process requirements and their clar
   :tags: Tool Verification Reports
   :implemented: NO
   :satisfies: PROCESS_gd_req__tool__attr_status
-  :parent_has_problem: NO
   :parent_covered: YES
 
   Docs-as-Code shall enforce that every Tool Verification Report includes a ``status``
@@ -629,9 +627,6 @@ This section provides an overview of current process requirements and their clar
 .. needextend:: c.this_doc() and type == 'tool_req'
   :safety: ASIL_B
   :security: NO
-
-.. needextend:: c.this_doc() and type == 'tool_req' and "YES" in parent_has_problem
-  :status: invalid
 
 .. needextend:: c.this_doc() and type == 'tool_req' and not status
   :status: valid

--- a/src/incremental.py
+++ b/src/incremental.py
@@ -53,6 +53,13 @@ if __name__ == "__main__":
         "--github_repo",
         help="GitHub repository to embed in the Sphinx build",
     )
+    parser.add_argument(
+        "--port",
+        help="Port to use for the live_preview ACTION. Default is 8000. "
+        "Use 0 for auto detection of a free port.",
+        default=8000,
+    )
+
     args = parser.parse_args()
     if args.debug:
         debugpy.listen(("0.0.0.0", args.debug_port))
@@ -87,7 +94,11 @@ if __name__ == "__main__":
     if action == "live_preview":
         sphinx_autobuild_main(
             # Note: bools need to be passed via '0' and '1' from the command line.
-            base_arguments + ["--define=disable_source_code_linker=1"]
+            base_arguments
+            + [
+                "--define=disable_source_code_linker=1",
+                f"--port={args.port}",
+            ]
         )
     else:
         sphinx_main(base_arguments)


### PR DESCRIPTION
This seems like a valid iteration. And I feel like we've hit a wall until some PRs in process description actually get merged. I don't want to keep this on a branch for multiple days.

I've also added the ability to specify a port for live_preview, as I was trying to view process 1.0.2 in parallel, which failed. It's now possible e.g. with `bazel run //process:live_preview_latest -- --port=0`