### PR TITLE
docs: Fix registration of HeaderService

### DIFF
--- a/src/extensions/score_header_service/header_service.py
+++ b/src/extensions/score_header_service/header_service.py
@@ -56,7 +56,8 @@ def register(app: Sphinx, env: BuildEnvironment, _: str | None) -> None:
     :param env: The Sphinx build environment.
     :param _: Additional argument not used.
     """
-    app.add_config_value("header_service_use_github_data", True, "env")
+    if not hasattr(app.config, "header_service_use_github_data"):
+        app.add_config_value("header_service_use_github_data", True, "env")
     data = SphinxNeedsData(env)
     services = data.get_or_create_services()
     services.register("header-service", HeaderService)


### PR DESCRIPTION
Esbonio crashes due to score_header_service extension being registered when trying to build for the second time.

Related: https://github.com/eclipse-score/score/issues/1117