### PR TITLE
Remove empty globs

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -83,7 +83,7 @@ def docs(source_files_to_scan_for_needs_links = None, source_dir = "docs", conf_
         sphinx_build_binary(
             name = "sphinx_build" + suffix,
             visibility = ["//visibility:public"],
-            data = ["@score_docs_as_code//src:docs_assets", "@score_docs_as_code//src:score_extension_files"] + external_needs_deps,
+            data = ["@score_docs_as_code//src:docs_assets", "@score_docs_as_code//src:docs_as_code_py_modules"] + external_needs_deps,
             deps = sphinx_requirements + deps,
         )
         _incremental(
@@ -191,7 +191,7 @@ def _docs(name = "docs", suffix = "", format = "html", external_needs_deps = lis
             "**/*.json",
             "**/*.csv",
             "**/*.inc",
-        ], exclude = ["**/tests/*"]),
+        ], exclude = ["**/tests/*"], allow_empty = True),
         config = ":conf.py",
         extra_opts = [
             "-W",
@@ -214,7 +214,7 @@ def _docs(name = "docs", suffix = "", format = "html", external_needs_deps = lis
 
     native.filegroup(
         name = "assets" + target_suffix,
-        srcs = native.glob(["_assets/**"]),
+        srcs = native.glob(["_assets/**"], allow_empty = True),
         visibility = ["//visibility:public"],
     )
 

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -49,6 +49,6 @@ docs(
     ],
     source_dir = "docs",
     source_files_to_scan_for_needs_links = [
-        "//src:score_extension_files",
+        "//src:docs_as_code_py_modules",
     ],
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -119,21 +119,6 @@ py_library(
 )
 
 filegroup(
-    name = "score_extension_files",
-    srcs = glob(
-        [
-            "src/**",
-        ],
-        exclude = [
-            "**/test/**",
-            "**/tests/**",
-            "**/__pycache__/**",
-        ],
-    ) + [":docs_as_code_py_modules"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
     name = "docs_assets",
     srcs = glob([
         "assets/**/*",
@@ -150,17 +135,6 @@ filegroup(
     srcs = [
         "requirements.txt",
     ],
-    visibility = ["//visibility:public"],
-)
-
-# Needed for 'test_rules_file_based'
-filegroup(
-    name = "test_rst_files",
-    srcs = glob([
-        "extensions/**/*.rst",
-        "extensions/**/*.py",
-        "conf.py",
-    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/src/extensions/score_metamodel/BUILD
+++ b/src/extensions/score_metamodel/BUILD
@@ -33,7 +33,7 @@ score_py_pytest(
     size = "small",
     srcs = glob(["tests/*.py"]),
     # All requirements already in the library so no need to have it double
-    data = ["//src:test_rst_files"] + glob(
+    data = glob(
         ["tests/**/*.rst"],
     ),
     deps = [":score_metamodel"],


### PR DESCRIPTION
Add support for bazel setting incompatible_disallow_empty_glob to detect
unintentional empty globs.

While doing that, I detected that there are some filegroups with empty globs:

* score_extension_files, replace its usages with docs_as_code_py_modules.
* test_rst_files: test content already covered by glob in score_metamodel_tests

In both cases, the globs were targeting subdirectories which are themselves bazel packages.
Therefore the glob does not match them.
