### PR TITLE
Fix source code linker errors

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_docs_as_code",
-    version = "0.4.0",
+    version = "0.4.1",
     compatibility_level = 0,
 )
 

--- a/docs/product/extensions/source_code_linker.md
+++ b/docs/product/extensions/source_code_linker.md
@@ -40,21 +40,22 @@ The extension uses two main components to integrate with Bazel:
         **Note:** The base_url is defined in `parse_source_files.py`. Currently set to: `https://github.com/eclipse-score/score/blob/`
 
 Produces JSON mapping file:
-```json
+The strings are split here to not enable tracking by the source code linker.
+```python
 [
     {
         "file": "src/implementation1.py",
         "line": 3,
-        "tag":"# req-Id:",
+        "tag":"#" + " req-Id:",
         "need": "TREQ_ID_1",
-        "full_line": "# req-Id: TREQ_ID_1"
+        "full_line": "#"+" req-Id: TREQ_ID_1"
     },
     {
         "file": "src/implementation2.py", 
         "line": 3,
-        "tag":"# req-Id:",
+        "tag":"#" + " req-Id:",
         "need": "TREQ_ID_1",
-        "full_line": "# req-Id: TREQ_ID_1"
+        "full_line": "#"+" req-Id: TREQ_ID_1"
     },
 ]
 ```

--- a/src/extensions/score_source_code_linker/tests/test_requirement_links.py
+++ b/src/extensions/score_source_code_linker/tests/test_requirement_links.py
@@ -201,30 +201,30 @@ def sample_needlinks():
         NeedLink(
             file=Path("src/implementation1.py"),
             line=3,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_1",
-            full_line="# req-Id: TREQ_ID_1",
+            full_line="#"+" req-Id: TREQ_ID_1",
         ),
         NeedLink(
             file=Path("src/implementation2.py"),
             line=3,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_1",
-            full_line="# req-Id: TREQ_ID_1",
+            full_line="#"+" req-Id: TREQ_ID_1",
         ),
         NeedLink(
             file=Path("src/implementation1.py"),
             line=9,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_2",
-            full_line="# req-Id: TREQ_ID_2",
+            full_line="#"+" req-Id: TREQ_ID_2",
         ),
         NeedLink(
             file=Path("src/bad_implementation.py"),
             line=2,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_200",
-            full_line="# req-Id: TREQ_ID_200",
+            full_line="#"+" req-Id: TREQ_ID_200",
         ),
     ]
 
@@ -452,9 +452,9 @@ def test_get_github_link_with_real_repo(git_repo):
     needlink = NeedLink(
         file=Path("src/test.py"),
         line=42,
-        tag="# req-Id:",
+        tag="#" + " req-Id:",
         need="REQ_001",
-        full_line="# req-Id: REQ_001",
+        full_line="#" + " req-Id: REQ_001",
     )
 
     result = get_github_link(git_repo, needlink)
@@ -502,9 +502,9 @@ def test_cache_file_with_encoded_comments(temp_dir):
         NeedLink(
             file=Path("src/test.py"),
             line=1,
-            tag="# req-Id:",
+            tag="#" + " req-Id:",
             need="TEST_001",
-            full_line="# req-Id: TEST_001",
+            full_line="#" + " req-Id: TEST_001",
         )
     ]
 
@@ -514,14 +514,14 @@ def test_cache_file_with_encoded_comments(temp_dir):
     # Check the raw JSON to verify encoding
     with open(cache_file, "r") as f:
         raw_content = f.read()
-        assert "# req-Id:" in raw_content  # Should be encoded
+        assert "#"+ " req-Id:" in raw_content  # Should be encoded
         assert "#-----req-Id:" not in raw_content  # Original should not be present
 
     # Load and verify decoding
     loaded_links = load_source_code_links_json(cache_file)
     assert len(loaded_links) == 1
-    assert loaded_links[0].tag == "# req-Id:"  # Should be decoded back
-    assert loaded_links[0].full_line == "# req-Id: TEST_001"
+    assert loaded_links[0].tag == "#"+" req-Id:"  # Should be decoded back
+    assert loaded_links[0].full_line == "#"+" req-Id: TEST_001"
 
 
 # Integration tests
@@ -561,19 +561,19 @@ def test_end_to_end_with_real_files(temp_dir, git_repo):
 
     (src_dir / "implementation1.py").write_text("""
 # Some implementation
-# req-Id: TREQ_ID_1
+#""" + """ req-Id: TREQ_ID_1
 def function1():
     pass
 
 # Another function
-# req-Id: TREQ_ID_2
+#""" + """ req-Id: TREQ_ID_2
 def function2():
     pass
 """)
 
     (src_dir / "implementation2.py").write_text("""
 # Another implementation
-# req-Id: TREQ_ID_1
+#""" + """ req-Id: TREQ_ID_1
 def another_function():
     pass
 """)
@@ -589,23 +589,23 @@ def another_function():
         NeedLink(
             file=Path("src/implementation1.py"),
             line=3,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_1",
-            full_line="# req-Id: TREQ_ID_1",
+            full_line="#"+" req-Id: TREQ_ID_1",
         ),
         NeedLink(
             file=Path("src/implementation1.py"),
             line=8,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_2",
-            full_line="# req-Id: TREQ_ID_2",
+            full_line="#"+" req-Id: TREQ_ID_2",
         ),
         NeedLink(
             file=Path("src/implementation2.py"),
             line=3,
-            tag="# req-Id:",
+            tag="#"+" req-Id:",
             need="TREQ_ID_1",
-            full_line="# req-Id: TREQ_ID_1",
+            full_line="#"+" req-Id: TREQ_ID_1",
         ),
     ]
 
@@ -652,9 +652,9 @@ def test_multiple_commits_hash_consistency(git_repo):
     needlink = NeedLink(
         file=Path("new_file.py"),
         line=1,
-        tag="# req-Id:",
+        tag="#" +" req-Id:",
         need="TEST_001",
-        full_line="# req-Id: TEST_001",
+        full_line="#"+" req-Id: TREQ_ID_1",
     )
 
     os.chdir(Path(git_repo).absolute())

--- a/src/extensions/score_source_code_linker/tests/test_source_link.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_link.py
@@ -99,13 +99,13 @@ def create_demo_files(sphinx_base_dir, git_repo_setup):
 def make_source_1():
     return """
 # This is a test implementation file
-# req-Id: TREQ_ID_1
+#""" + """ req-Id: TREQ_ID_1
 def some_function():
     pass
 
 # Some other code here
 # More code...
-# req-Id: TREQ_ID_2
+#""" """ req-Id: TREQ_ID_2
 def another_function():
     pass
 """
@@ -114,7 +114,7 @@ def another_function():
 def make_source_2():
     return """
 # Another implementation file
-# req-Id: TREQ_ID_1
+#"""+ """ req-Id: TREQ_ID_1
 class SomeClass:
     def method(self):
         pass
@@ -124,7 +124,7 @@ class SomeClass:
 
 def make_bad_source():
     return """
-# req-Id: TREQ_ID_200
+#""" + """ req-Id: TREQ_ID_200
 def This_Should_Error(self):
     pass
 


### PR DESCRIPTION
Source code linker errored when it parsed the test & documentation files.
This removes those tags in order to stop those errors