### PR TITLE
Enhance validation for graph checks error messages

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -141,7 +141,6 @@ def load_metamodel_data():
     types_dict = data.get("needs_types", {})
     links_dict = data.get("needs_extra_links", {})
     graph_check_dict = data.get("graph_checks", {})
-
     global_base_options = data.get("needs_types_base_options", {})
     global_base_options_optional_opts = global_base_options.get("optional_options", {})
 

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -14,13 +14,12 @@ import operator
 from collections.abc import Callable
 from typing import Any, Literal
 
-from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType, NeedsView
-
 from score_metamodel import (
     CheckLogger,
     graph_check,
 )
+from sphinx.application import Sphinx
+from sphinx_needs.data import NeedsInfoType, NeedsView
 
 
 def eval_need_check(need: NeedsInfoType, check: str, log: CheckLogger) -> bool:
@@ -137,30 +136,46 @@ def check_metamodel_graph(
     # Convert list to dictionary for easy lookup
     needs_dict_all = {need["id"]: need for need in all_needs.values()}
     needs_local = list(all_needs.filter_is_external(False).values())
+
     # Iterate over all graph checks
-    for check in graph_checks_global.items():
-        apply, eval = check[1].values()
-        # Get all needs that match the selection criteria
+    for check_name, check_config in graph_checks_global.items():
+        apply = check_config.get("needs")
+        eval = check_config.get("check")
+        explanation = check_config.get("explanation", "")
+
+        # Get all needs matching the selection criteria
         selected_needs = get_need_selection(needs_local, apply, log)
 
         for need in selected_needs:
             for parent_relation in list(eval.keys()):
                 if parent_relation not in need:
-                    msg = f"Attribute not defined: {parent_relation}"
+                    msg = f"Attribute not defined: `{parent_relation}` in need `{need['id']}`."
+                    if explanation:
+                        msg += f" Explanation: {explanation}"
                     log.warning_for_need(need, msg)
                     continue
+
                 parent_ids = need[parent_relation]
+                if not isinstance(parent_ids, list):
+                    parent_ids = [parent_ids]
 
                 for parent_id in parent_ids:
                     parent_need = needs_dict_all.get(parent_id)
                     if parent_need is None:
-                        msg = f"Parent need `{parent_id}` not found in needs_dict."
+                        msg = (
+                            f"Parent need `{parent_id}` referenced in `{need['id']}` "
+                            f"not found in needs_dict."
+                        )
+                        if explanation:
+                            msg += f" Explanation: {explanation}"
                         log.warning_for_need(need, msg)
                         continue
 
                     if not eval_need_condition(parent_need, eval[parent_relation], log):
                         msg = (
-                            f"parent need `{parent_id}` does not fulfill "
-                            f"condition `{eval[parent_relation]}`."
+                            f"Parent need `{parent_id}` does not fulfill "
+                            f"condition `{eval[parent_relation]}` for `{need['id']}`."
                         )
+                        if explanation:
+                            msg += f" Explanation: {explanation}"
                         log.warning_for_need(need, msg)

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -12,7 +12,8 @@
 # *******************************************************************************
 import operator
 from collections.abc import Callable
-from typing import Any, Literal
+from functools import reduce
+from typing import Any
 
 from score_metamodel import (
     CheckLogger,
@@ -54,22 +55,14 @@ def eval_need_check(need: NeedsInfoType, check: str, log: CheckLogger) -> bool:
     return oper[parts[1]](need[parts[0]], parts[2])
 
 
+
 def eval_need_condition(
     need: NeedsInfoType, condition: str | dict[str, list[Any]], log: CheckLogger
 ) -> bool:
-    """Evaluate a condition on a need:
-    1. Check if the condition is only a simple check (e.g. "status == valid")
-       If so call the check function.
-    2. If the condition is a combination of multiple checks
-       (e.g. "and: [check1, check2]")
-       Recursively call the eval_need_function for each check and combine the
-       results with the binary operation which was specified in the yaml file.
-    """
-
     oper: dict[str, Any] = {
         "and": operator.and_,
         "or": operator.or_,
-        "not": operator.not_,
+        "not": lambda x: not x,
         "xor": operator.xor,
     }
 
@@ -79,16 +72,15 @@ def eval_need_condition(
     cond: str = list(condition.keys())[0]
     vals: list[Any] = list(condition.values())[0]
 
-    if cond in ["and", "or", "xor", "not"]:
-        for i in range(len(vals) - 1):
-            return oper[cond](
-                eval_need_condition(need, vals[i], log),
-                eval_need_condition(need, vals[i + 1], log),
-            )
-    else:
-        raise ValueError(f"Binary Operator not defined: {vals}")
+    if cond == "not":
+        if not isinstance(vals, list) or len(vals) != 1:
+            raise ValueError("Operator 'not' requires exactly one operand.")
+        return oper["not"](eval_need_condition(need, vals[0], log))
 
-    return True
+    if cond in ["and", "or", "xor"]:
+        return reduce(lambda a, b: oper[cond](a, b),
+                      (eval_need_condition(need, val, log) for val in vals))
+    raise ValueError(f"Unsupported condition operator: {cond}")
 
 
 def get_need_selection(
@@ -142,6 +134,7 @@ def check_metamodel_graph(
         apply = check_config.get("needs")
         eval = check_config.get("check")
         explanation = check_config.get("explanation", "")
+        assert explanation != "", f"Explanation for graph check {check_name} is missing. Explanations are mandatory for graph checks."
 
         # Get all needs matching the selection criteria
         selected_needs = get_need_selection(needs_local, apply, log)
@@ -150,8 +143,6 @@ def check_metamodel_graph(
             for parent_relation in list(eval.keys()):
                 if parent_relation not in need:
                     msg = f"Attribute not defined: `{parent_relation}` in need `{need['id']}`."
-                    if explanation:
-                        msg += f" Explanation: {explanation}"
                     log.warning_for_need(need, msg)
                     continue
 
@@ -163,19 +154,15 @@ def check_metamodel_graph(
                     parent_need = needs_dict_all.get(parent_id)
                     if parent_need is None:
                         msg = (
-                            f"Parent need `{parent_id}` referenced in `{need['id']}` "
-                            f"not found in needs_dict."
+                            f"Parent need `{parent_id}` not found in needs_dict."
                         )
-                        if explanation:
-                            msg += f" Explanation: {explanation}"
                         log.warning_for_need(need, msg)
                         continue
 
                     if not eval_need_condition(parent_need, eval[parent_relation], log):
                         msg = (
                             f"Parent need `{parent_id}` does not fulfill "
-                            f"condition `{eval[parent_relation]}` for `{need['id']}`."
+                            f"condition `{eval[parent_relation]}`."
+                            f" Explanation: {explanation}"
                         )
-                        if explanation:
-                            msg += f" Explanation: {explanation}"
                         log.warning_for_need(need, msg)

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -694,6 +694,7 @@ graph_checks:
       condition: safety == QM
     check:
       satisfies: safety == QM
+    explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
   # If need-req is `ASIL_B`, parent must be `QM` or `ASIL_B`.
   req_safety_linkage_asil_b:
     needs:
@@ -701,6 +702,7 @@ graph_checks:
       condition: safety == ASIL_B
     check:
       satisfies: safety != ASIL_D
+    explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
   # saf - ID gd_req__saf_linkage_safety
   # It shall be checked that Safety Analysis (DFA and FMEA) can only be linked via mitigate against
   #  - <Feature | Component | AoU> Requirements with the same ASIL or
@@ -712,3 +714,4 @@ graph_checks:
       condition: safety == ASIL_B
     check:
       mitigates: safety != QM
+    explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.

--- a/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
@@ -35,7 +35,7 @@
 
 
 .. Positive Test: Child requirement QM. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__1: parent need `feat_req__parent__QM` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
+#EXPECT-NOT: feat_req__child__1: Parent need `feat_req__parent__QM` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 1
    :id: feat_req__child__1
@@ -43,8 +43,9 @@
    :satisfies: feat_req__parent__QM
    :status: valid
 
+
 .. Positive Test: Child requirement ASIL B. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__2: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
+#EXPECT-NOT: feat_req__child__2: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 2
    :id: feat_req__child__2
@@ -52,8 +53,9 @@
    :satisfies: feat_req__parent__ASIL_B
    :status: valid
 
+
 .. Positive Test: Child requirement ASIL D. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__3: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
+#EXPECT-NOT: feat_req__child__3: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 3
    :id: feat_req__child__3
@@ -61,8 +63,9 @@
    :satisfies: feat_req__parent__ASIL_D
    :status: valid
 
+
 .. Negative Test: Child requirement QM. Parent requirement is `ASIL_B`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__4: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
+#EXPECT: feat_req__child__4: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. comp_req:: Child requirement 4
    :id: feat_req__child__4
@@ -70,8 +73,9 @@
    :satisfies: feat_req__parent__ASIL_B
    :status: valid
 
+
 .. Negative Test: Child requirement QM. Parent requirement is `ASIL_D`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__5: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
+#EXPECT: feat_req__child__5: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. comp_req:: Child requirement 5
    :id: feat_req__child__5
@@ -79,8 +83,9 @@
    :satisfies: feat_req__parent__ASIL_D
    :status: valid
 
+
 .. Positive Test: Child requirement ASIL_B. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__6: parent need `feat_req__parent__QM` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
+#EXPECT-NOT: feat_req__child__6: Parent need `feat_req__parent__QM` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. feat_req:: Child requirement 6
    :id: feat_req__child__6
@@ -88,8 +93,9 @@
    :satisfies: feat_req__parent__QM
    :status: valid
 
+
 .. Positive Test: Child requirement ASIL_B. Parent requirement has the correct related safety level. Parent requirement is `ASIL_B`.
-#EXPECT-NOT: feat_req__child__7: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
+#EXPECT-NOT: feat_req__child__7: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. feat_req:: Child requirement 7
    :id: feat_req__child__7
@@ -97,15 +103,15 @@
    :satisfies: feat_req__parent__ASIL_B
    :status: valid
 
+
 .. Negative Test: Child requirement ASIL_B. Parent requirement is `ASIL_D`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__8: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
+#EXPECT: feat_req__child__8: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. comp_req:: Child requirement 8
    :id: feat_req__child__8
    :safety: ASIL_B
    :satisfies: feat_req__parent__ASIL_D
    :status: valid
-
 
 
 .. Parent requirement does not exist
@@ -118,9 +124,10 @@
    :satisfies: feat_req__parent0__abcd
 
 
+
 .. Mitigation of Safety Analysis (FMEA and DFA) shall be checked. Mitigation shall have the same or higher safety level than the analysed item.
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_saf_dfa__child__10: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT: feat_saf_dfa__child__10: Parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 10
    :id: feat_saf_dfa__child__10
@@ -128,8 +135,9 @@
    :status: valid
    :mitigates: feat_req__parent__QM
 
+
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_dfa__child__11: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_saf_dfa__child__11: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 11
    :id: feat_saf_dfa__child__11
@@ -137,8 +145,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_B
 
+
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_dfa__child__12: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_saf_dfa__child__12: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 12
    :id: feat_saf_dfa__child__12
@@ -146,8 +155,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_D
 
+
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: comp_saf_dfa__child__13: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT: comp_saf_dfa__child__13: Parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 13
    :id: comp_saf_dfa__child__13
@@ -155,8 +165,9 @@
    :status: valid
    :mitigates: feat_req__parent__QM
 
+
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_dfa__child__14: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: comp_saf_dfa__child__14: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 14
    :id: comp_saf_dfa__child__14
@@ -164,8 +175,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_B
 
+
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_dfa__child__15: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: comp_saf_dfa__child__15: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 15
    :id: comp_saf_dfa__child__15
@@ -173,8 +185,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_D
 
+
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_plat_saf_dfa__child__16: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT: feat_plat_saf_dfa__child__16: Parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 16
    :id: feat_plat_saf_dfa__child__16
@@ -182,8 +195,9 @@
    :status: valid
    :mitigates: feat_req__parent__QM
 
+
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_plat_saf_dfa__child__17: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_plat_saf_dfa__child__17: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 17
    :id: feat_plat_saf_dfa__child__17
@@ -191,8 +205,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_B
 
+
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_plat_saf_dfa__child__18: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_plat_saf_dfa__child__18: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 18
    :id: feat_plat_saf_dfa__child__15
@@ -200,8 +215,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_D
 
+
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_saf_fmea__child__19: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT: feat_saf_fmea__child__19: Parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 19
    :id: feat_saf_fmea__child__19
@@ -209,8 +225,9 @@
    :status: valid
    :mitigates: feat_req__parent__QM
 
+
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_fmea__child__20: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_saf_fmea__child__20: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 20
    :id: feat_saf_fmea__child__20
@@ -218,8 +235,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_B
 
+
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_fmea__child__21: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: feat_saf_fmea__child__21: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 21
    :id: feat_saf_fmea__child__21
@@ -227,8 +245,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_D
 
+
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: comp_saf_fmea__child__22: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT: comp_saf_fmea__child__22: Parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_fmea:: Child requirement 22
    :id: comp_saf_fmea__child__22
@@ -236,8 +255,9 @@
    :status: valid
    :mitigates: feat_req__parent__QM
 
+
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_fmea__child__23: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+#EXPECT-NOT: comp_saf_fmea__child__23: Parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_fmea:: Child requirement 23
    :id: comp_saf_fmea__child__23
@@ -245,9 +265,9 @@
    :status: valid
    :mitigates: feat_req__parent__ASIL_B
 
-.. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_fmea__child__24: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
+.. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
+#EXPECT-NOT: comp_saf_fmea__child__24: Parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_fmea:: Child requirement 24
    :id: comp_saf_fmea__child__24

--- a/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
@@ -35,7 +35,7 @@
 
 
 .. Positive Test: Child requirement QM. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__1: parent need `feat_req__parent__QM` does not fulfill condition `safety == QM`.
+#EXPECT-NOT: feat_req__child__1: parent need `feat_req__parent__QM` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 1
    :id: feat_req__child__1
@@ -44,7 +44,7 @@
    :status: valid
 
 .. Positive Test: Child requirement ASIL B. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__2: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`.
+#EXPECT-NOT: feat_req__child__2: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 2
    :id: feat_req__child__2
@@ -53,7 +53,7 @@
    :status: valid
 
 .. Positive Test: Child requirement ASIL D. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__3: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`.
+#EXPECT-NOT: feat_req__child__3: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. feat_req:: Child requirement 3
    :id: feat_req__child__3
@@ -62,7 +62,7 @@
    :status: valid
 
 .. Negative Test: Child requirement QM. Parent requirement is `ASIL_B`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__4: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`.
+#EXPECT: feat_req__child__4: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. comp_req:: Child requirement 4
    :id: feat_req__child__4
@@ -71,7 +71,7 @@
    :status: valid
 
 .. Negative Test: Child requirement QM. Parent requirement is `ASIL_D`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__5: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`.
+#EXPECT: feat_req__child__5: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety == QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is QM and its status is valid.
 
 .. comp_req:: Child requirement 5
    :id: feat_req__child__5
@@ -80,7 +80,7 @@
    :status: valid
 
 .. Positive Test: Child requirement ASIL_B. Parent requirement has the correct related safety level. Parent requirement is `QM`.
-#EXPECT-NOT: feat_req__child__6: parent need `feat_req__parent__QM` does not fulfill condition `safety != ASIL_D`.
+#EXPECT-NOT: feat_req__child__6: parent need `feat_req__parent__QM` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. feat_req:: Child requirement 6
    :id: feat_req__child__6
@@ -89,7 +89,7 @@
    :status: valid
 
 .. Positive Test: Child requirement ASIL_B. Parent requirement has the correct related safety level. Parent requirement is `ASIL_B`.
-#EXPECT-NOT: feat_req__child__7: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != ASIL_D`.
+#EXPECT-NOT: feat_req__child__7: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. feat_req:: Child requirement 7
    :id: feat_req__child__7
@@ -98,7 +98,7 @@
    :status: valid
 
 .. Negative Test: Child requirement ASIL_B. Parent requirement is `ASIL_D`. Child cant fulfill the safety level of the parent.
-#EXPECT: feat_req__child__8: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != ASIL_D`.
+#EXPECT: feat_req__child__8: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != ASIL_D`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not ASIL_D and its status is valid.
 
 .. comp_req:: Child requirement 8
    :id: feat_req__child__8
@@ -120,7 +120,7 @@
 
 .. Mitigation of Safety Analysis (FMEA and DFA) shall be checked. Mitigation shall have the same or higher safety level than the analysed item.
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_saf_dfa__child__10: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`.
+#EXPECT: feat_saf_dfa__child__10: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 10
    :id: feat_saf_dfa__child__10
@@ -129,7 +129,7 @@
    :mitigates: feat_req__parent__QM
 
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_dfa__child__11: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_saf_dfa__child__11: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 11
    :id: feat_saf_dfa__child__11
@@ -138,7 +138,7 @@
    :mitigates: feat_req__parent__ASIL_B
 
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_dfa__child__12: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_saf_dfa__child__12: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_dfa:: Child requirement 12
    :id: feat_saf_dfa__child__12
@@ -147,7 +147,7 @@
    :mitigates: feat_req__parent__ASIL_D
 
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: comp_saf_dfa__child__13: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`.
+#EXPECT: comp_saf_dfa__child__13: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 13
    :id: comp_saf_dfa__child__13
@@ -156,7 +156,7 @@
    :mitigates: feat_req__parent__QM
 
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_dfa__child__14: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: comp_saf_dfa__child__14: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 14
    :id: comp_saf_dfa__child__14
@@ -165,7 +165,7 @@
    :mitigates: feat_req__parent__ASIL_B
 
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_dfa__child__15: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: comp_saf_dfa__child__15: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_dfa:: Child requirement 15
    :id: comp_saf_dfa__child__15
@@ -174,7 +174,7 @@
    :mitigates: feat_req__parent__ASIL_D
 
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_plat_saf_dfa__child__16: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`.
+#EXPECT: feat_plat_saf_dfa__child__16: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 16
    :id: feat_plat_saf_dfa__child__16
@@ -183,7 +183,7 @@
    :mitigates: feat_req__parent__QM
 
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_plat_saf_dfa__child__17: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_plat_saf_dfa__child__17: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 17
    :id: feat_plat_saf_dfa__child__17
@@ -192,7 +192,7 @@
    :mitigates: feat_req__parent__ASIL_B
 
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_plat_saf_dfa__child__18: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_plat_saf_dfa__child__18: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_plat_saf_dfa:: Child requirement 18
    :id: feat_plat_saf_dfa__child__15
@@ -201,7 +201,7 @@
    :mitigates: feat_req__parent__ASIL_D
 
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: feat_saf_fmea__child__19: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`.
+#EXPECT: feat_saf_fmea__child__19: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 19
    :id: feat_saf_fmea__child__19
@@ -210,7 +210,7 @@
    :mitigates: feat_req__parent__QM
 
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_fmea__child__20: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_saf_fmea__child__20: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 20
    :id: feat_saf_fmea__child__20
@@ -219,7 +219,7 @@
    :mitigates: feat_req__parent__ASIL_B
 
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: feat_saf_fmea__child__21: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: feat_saf_fmea__child__21: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. feat_saf_fmea:: Child requirement 21
    :id: feat_saf_fmea__child__21
@@ -228,7 +228,7 @@
    :mitigates: feat_req__parent__ASIL_D
 
 .. Negative Test: Linked to a mitigation that is lower than the safety level of the analysed item.
-#EXPECT: comp_saf_fmea__child__22: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`.
+#EXPECT: comp_saf_fmea__child__22: parent need `feat_req__parent__QM` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_fmea:: Child requirement 22
    :id: comp_saf_fmea__child__22
@@ -237,7 +237,7 @@
    :mitigates: feat_req__parent__QM
 
 .. Positive Test: Linked to a mitigation that is equal to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_fmea__child__23: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: comp_saf_fmea__child__23: parent need `feat_req__parent__ASIL_B` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
 
 .. comp_saf_fmea:: Child requirement 23
    :id: comp_saf_fmea__child__23
@@ -246,7 +246,8 @@
    :mitigates: feat_req__parent__ASIL_B
 
 .. Positive Test: Linked to a mitigation that is higher to the safety level of the analysed item.
-#EXPECT-NOT: comp_saf_fmea__child__24: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`.
+#EXPECT-NOT: comp_saf_fmea__child__24: parent need `feat_req__parent__ASIL_D` does not fulfill condition `safety != QM`. Explanation: An ASIL requirement must link at least one parent/upstream ASIL requirement for correct decomposition. Please ensure the parent’s safety level is not QM and its status is valid.
+
 
 .. comp_saf_fmea:: Child requirement 24
    :id: comp_saf_fmea__child__24


### PR DESCRIPTION
- Adding Attribute explanation to the graph checks in the metamodel 

- Extract the explanation attribute and add it  to the log when we have errors for graph checks
 
- Assert to ensure the explanation attribute is there

- Adapt the RST Tests to the new log error format output

close: https://github.com/eclipse-score/docs-as-code/issues/115
 
 