### PR TITLE
Extend weak content check for tool needs

### DIFF
--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -112,7 +112,14 @@ This section provides an overview of current process requirements and their clar
   :parent_covered: NO: Can not cover 'ISO/IEC/IEEE/29148'
   :implemented: NO
 
-  Docs-as-Code shall enforce that each Need contains a description (content).
+  Docs-as-Code shall enforce that each Need contains a description (content) and no weak word like the following list is in that description:
+
+  * just
+  * about
+  * really
+  * some
+  * thing
+  * absolutely
 
 ----------------------------
 🔒 Security Classification

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -110,7 +110,7 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_common_attr_description
   :tags: Common Attributes
   :parent_covered: NO: Can not cover 'ISO/IEC/IEEE/29148'
-  :implemented: NO
+  :implemented: YES
 
   Docs-as-Code shall enforce that each Need contains a description (content) and no weak word like the following list is in that description:
 

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -79,7 +79,7 @@ This section provides an overview of current process requirements and their clar
   * A prefix indicating the need type (e.g. `feature__`)
   * A middle part matching the hierarchical structure of the need:
      * For requirements: a portion of the feature tree or a component acronym
-     * For architecture elements: the structural element (e.g. some part of the feature tree, component acronym)
+     * For architecture elements: the structural element (e.g. specific part of the feature tree, component acronym)
   * Additional descriptive text to ensure human readability
 
 

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -110,9 +110,17 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_common_attr_description
   :tags: Common Attributes
   :parent_covered: NO: Can not cover 'ISO/IEC/IEEE/29148'
+  :implemented: NO
+
+  Docs-as-Code shall enforce that each Need contains a description (content).
+
+
+.. tool_req:: Enforces description wording rules
+  :id: tool_req__docs_common_attr_description_wording
+  :tags: Common Attributes
   :implemented: YES
 
-  Docs-as-Code shall enforce that each Need contains a description (content) and no weak word like the following list is in that description:
+  Docs-as-Code shall enforce that Need description do not contain the following words:
 
   * just
   * about
@@ -120,6 +128,7 @@ This section provides an overview of current process requirements and their clar
   * some
   * thing
   * absolutely
+
 
 ----------------------------
 🔒 Security Classification

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -116,19 +116,14 @@ This section provides an overview of current process requirements and their clar
 
 
 .. tool_req:: Enforces description wording rules
-  :id: tool_req__docs_common_attr_description_wording
+  :id: tool_req__docs_common_attr_desc_wording
   :tags: Common Attributes
   :implemented: YES
   :satisfies: PROCESS_gd_req__req__attr_desc_weak
   :parent_covered: YES
-  Docs-as-Code shall enforce that Need description do not contain the following words:
 
-  * just
-  * about
-  * really
-  * some
-  * thing
-  * absolutely
+
+  Docs-as-Code shall enforce that Need description do not contain the weak words that are defined in the metamodel
 
 
 ----------------------------

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -120,7 +120,7 @@ This section provides an overview of current process requirements and their clar
   :tags: Common Attributes
   :implemented: YES
   :satisfies: PROCESS_gd_req__req__attr_desc_weak
-
+  :parent_covered: YES
   Docs-as-Code shall enforce that Need description do not contain the following words:
 
   * just

--- a/docs/product/requirements.rst
+++ b/docs/product/requirements.rst
@@ -119,6 +119,7 @@ This section provides an overview of current process requirements and their clar
   :id: tool_req__docs_common_attr_description_wording
   :tags: Common Attributes
   :implemented: YES
+  :satisfies: PROCESS_gd_req__req__attr_desc_weak
 
   Docs-as-Code shall enforce that Need description do not contain the following words:
 

--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -131,11 +131,10 @@ def check_description(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     ---
     """
     weak_words = app.config.weak_words
-    if need["type"] in [
-        "stkh_req",
-        "feat_req",
-        "comp_req",
-    ] and need.get("content", None):
+    need_options = get_need_type(app.config.needs_types, need["type"])
+
+    tags = need_options.get("tags", [])
+    if "requirement_excl_process" in tags and need.get("content", None):
         for word in weak_words:
             if word in need["content"]:
                 msg = f"contains a weak word: `{word}`. Please revise the description."

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -75,7 +75,6 @@ needs_types:
       links: ^.*$
     tags:
       - requirement
-
   std_wp:
     title: Standard Work Product
     prefix: std_wp__
@@ -235,7 +234,7 @@ needs_types:
       hash: ^.*$
     tags:
       - requirement
-
+      - requirement_excl_process
   # req-Id: tool_req__docs_req_types
   feat_req:
     title: Feature Requirement
@@ -261,6 +260,7 @@ needs_types:
       hash: ^.*$
     tags:
       - requirement
+      - requirement_excl_process
 
   # req-Id: tool_req__docs_req_types
   comp_req:
@@ -286,6 +286,7 @@ needs_types:
       hash: ^.*$
     tags:
       - requirement
+      - requirement_excl_process
 
   # req-Id: tool_req__docs_req_types
   tool_req:
@@ -315,6 +316,7 @@ needs_types:
       parent_has_problem: ^.*$
     tags:
       - requirement
+      - requirement_excl_process
 
   # req-Id: tool_req__docs_req_types
   aou_req:

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -22,7 +22,7 @@ needs_types_base_options:
       - shall
       - must
       - will
-    # req-Id: tool_req__docs_common_attr_description
+    # req-Id: tool_req__docs_common_attr_desc_wording
     content:
       - just
       - about

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -73,8 +73,7 @@ needs_types:
       status: ^(valid)$
     optional_links:
       links: ^.*$
-    tags:
-      - requirement
+
   std_wp:
     title: Standard Work Product
     prefix: std_wp__
@@ -235,6 +234,7 @@ needs_types:
     tags:
       - requirement
       - requirement_excl_process
+
   # req-Id: tool_req__docs_req_types
   feat_req:
     title: Feature Requirement
@@ -341,7 +341,6 @@ needs_types:
       mitigates: ^.*$
     tags:
       - requirement
-
 
   # Architecture
   feat_arc_sta:


### PR DESCRIPTION
Extend weak content check for tool needs and correct failed  Tool requirements in the build

close: https://github.com/eclipse-score/docs-as-code/issues/148