### PR TITLE
Update DevContainer Usage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,5 @@
     "name": "eclipse-s-core",
     "image": "ghcr.io/eclipse-score/devcontainer:latest",
     "initializeCommand": "mkdir -p ${localEnv:HOME}/.cache/bazel",
-    "postCreateCommand": "bazel run //docs:ide_support"
+    "updateContentCommand": "bazel run //docs:ide_support"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,11 +32,6 @@
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "bazel.lsp.command": "bazel",
-  "bazel.lsp.args": [
-    "run",
-    "//:starpls_server"
-  ],
 
   // Disable internal type checking, since we use basedpyright
   "python.analysis.typeCheckingMode": "off",


### PR DESCRIPTION
- Remove broken Starlark LSP Server start command (a working one is already part of the DevContainer)
- Move the ide_support call a bit earlier into the lifecycle