### PR TITLE
Add mitigates back in

### DIFF
--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -620,11 +620,11 @@ needs_types:
       status: ^(valid|invalid)$
 
   # DFA (Dependent Failure Analysis)
-  feat_plat_saf_dfa:
+  plat_saf_dfa:
     title: Feature Dependent Failure Analysis
-    prefix: feat_plat_saf_dfa__
+    prefix: plat_saf_dfa__
     mandatory_options:
-      id: ^feat_plat_saf_dfa__[0-9a-z_]+$
+      id: ^plat_saf_dfa__[0-9a-z_]+$
       failure_id: ^.*$
       failure_effect: ^.*$
       sufficient: ^(yes|no)$
@@ -838,7 +838,7 @@ graph_checks:
   # as the corresponding ASIL of the Feature or Component that is analyzed.
   saf_linkage_safety:
     needs:
-      include: feat_saf_fmea, comp_saf_fmea, feat_plat_saf_dfa, feat_saf_dfa, comp_saf_dfa
+      include: feat_saf_fmea, comp_saf_fmea, plat_saf_dfa, feat_saf_dfa, comp_saf_dfa
       condition: safety == ASIL_B
     check:
       mitigated_by: safety != QM


### PR DESCRIPTION
It currently is still used by process (inside AoU's). 

Until this is clarified if mitigates or mitiaged_by should be used, this will be added back in to not break compatibility.