### PR TITLE
docs: Allow needs_json to be visible

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -139,4 +139,5 @@ def docs(source_dir = "docs", data = [], deps = []):
         formats = ["needs"],
         sphinx = ":sphinx_build",
         tools = data,
+        visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
Make for example @score_platform//:needs_json visible in third repo.

Resolves: https://github.com/eclipse-score/score/issues/1601