### PR TITLE
Add assert for existence of high CHECK in RST file tests and make Uni…

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -65,13 +65,16 @@ def parse_checks_filter(filter: str) -> list[str]:
     checks = [check.strip() for check in filter.split(",")]
 
     # Validate all checks exist in either local_checks or graph_checks
-    all_check_names = {c.__name__ for c in local_checks} | {c.__name__ for c in graph_checks}
+    all_check_names = {c.__name__ for c in local_checks} | {
+        c.__name__ for c in graph_checks
+    }
     for check in checks:
         assert check in all_check_names, (
             f"Check: '{check}' is not one of the defined local or graph checks"
         )
 
     return checks
+
 
 def discover_checks():
     """

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -53,12 +53,9 @@ class ProhibitedWordCheck:
 
 def parse_checks_filter(filter: str) -> list[str]:
     """
-    Parses the checks filter string into a list of individual check names.
-    - When empty, returns an empty list, meaning all available checks are enabled.
-    - Strips whitespace around each check name from the comma-separated list.
-    - Asserts that each provided check name exists in either the registered
-      `local_checks` or `graph_checks`. If a name is not found, the build will
-      fail immediately with an assertion error.
+    Parses a comma-separated list of check names.
+    Returns all names after trimming spaces and ensures
+    each exists in local_checks or graph_checks.
     """
     if not filter:
         return []

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -53,13 +53,25 @@ class ProhibitedWordCheck:
 
 def parse_checks_filter(filter: str) -> list[str]:
     """
-    Parse the checks filter string into a list of individual checks.
-    When empty, an empty list is returned = all checks are enabled.
+    Parses the checks filter string into a list of individual check names.
+    - When empty, returns an empty list, meaning all available checks are enabled.
+    - Strips whitespace around each check name from the comma-separated list.
+    - Asserts that each provided check name exists in either the registered
+      `local_checks` or `graph_checks`. If a name is not found, the build will
+      fail immediately with an assertion error.
     """
     if not filter:
         return []
-    return [check.strip() for check in filter.split(",")]
+    checks = [check.strip() for check in filter.split(",")]
 
+    # Validate all checks exist in either local_checks or graph_checks
+    all_check_names = {c.__name__ for c in local_checks} | {c.__name__ for c in graph_checks}
+    for check in checks:
+        assert check in all_check_names, (
+            f"Check: '{check}' is not one of the defined local or graph checks"
+        )
+
+    return checks
 
 def discover_checks():
     """

--- a/src/extensions/score_metamodel/tests/test_metamodel__init__.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel__init__.py
@@ -22,6 +22,7 @@ from src.extensions.score_metamodel.__init__ import (
 def dummy_local_check(app, need, log):
     pass
 
+
 def dummy_graph_check(app, needs_view, log):
     pass
 

--- a/src/extensions/score_metamodel/tests/test_metamodel__init__.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel__init__.py
@@ -37,24 +37,25 @@ def setup_checks():
 
 
 def test_returns_empty_list_when_filter_is_empty():
+    """Return an empty list if no filter string is provided."""
     assert parse_checks_filter("") == []
 
 
 def test_returns_valid_checks():
+    """Return the provided valid check names."""
     result = parse_checks_filter("dummy_local_check,dummy_graph_check")
     assert result == ["dummy_local_check", "dummy_graph_check"]
 
 
 def test_strips_whitespace():
+    """Remove surrounding spaces from each check name."""
     result = parse_checks_filter(" dummy_local_check , dummy_graph_check ")
     assert result == ["dummy_local_check", "dummy_graph_check"]
 
 
 def test_raises_assertion_for_invalid_check():
-    # This name does not exist in either local_checks or graph_checks
+    """Raise AssertionError if a check name is unknown."""
     with pytest.raises(AssertionError) as exc_info:
         parse_checks_filter("non_existing_check")
-
-    # Ensure the error message is correct
     assert "non_existing_check" in str(exc_info.value)
     assert "not one of the defined local or graph checks" in str(exc_info.value)

--- a/src/extensions/score_metamodel/tests/test_metamodel__init__.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel__init__.py
@@ -1,0 +1,59 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+import pytest
+
+from src.extensions.score_metamodel.__init__ import (
+    graph_checks,
+    local_checks,
+    parse_checks_filter,
+)
+
+
+def dummy_local_check(app, need, log):
+    pass
+
+def dummy_graph_check(app, needs_view, log):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def setup_checks():
+    """Reset and set test-only local and graph checks before each test."""
+    local_checks.clear()
+    graph_checks.clear()
+    local_checks.append(dummy_local_check)
+    graph_checks.append(dummy_graph_check)
+
+
+def test_returns_empty_list_when_filter_is_empty():
+    assert parse_checks_filter("") == []
+
+
+def test_returns_valid_checks():
+    result = parse_checks_filter("dummy_local_check,dummy_graph_check")
+    assert result == ["dummy_local_check", "dummy_graph_check"]
+
+
+def test_strips_whitespace():
+    result = parse_checks_filter(" dummy_local_check , dummy_graph_check ")
+    assert result == ["dummy_local_check", "dummy_graph_check"]
+
+
+def test_raises_assertion_for_invalid_check():
+    # This name does not exist in either local_checks or graph_checks
+    with pytest.raises(AssertionError) as exc_info:
+        parse_checks_filter("non_existing_check")
+
+    # Ensure the error message is correct
+    assert "non_existing_check" in str(exc_info.value)
+    assert "not one of the defined local or graph checks" in str(exc_info.value)


### PR DESCRIPTION
Add an assert for the existence of the high CHECK name in the RST file tests in the list of defined local or graph checks, and create a unit test for that.


close: https://github.com/eclipse-score/docs-as-code/issues/168