### PR TITLE
Fix source code links strings in code

### DIFF
--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -24,7 +24,7 @@ def get_need_type(needs_types: list[ScoreNeedType], directive: str) -> ScoreNeed
     raise ValueError(f"Need type {directive} not found in needs_types")
 
 
-# req-Id: gd_req__req_attr_uid
+# req-Id: tool_req__docs_common_attr_id_scheme
 @local_check
 def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     """
@@ -86,8 +86,8 @@ def _check_options_for_prohibited_words(
                 log.warning_for_need(need, msg)
 
 
-# req-Id: gd_req__req_attr_desc_weak
-# req-Id: gd_req__requirements_attr_title
+# req-Id: tool_req__docs_common_attr_desc_wording
+# req-Id: tool_req__docs_common_attr_title
 @local_check
 def check_for_prohibited_words(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     need_options = get_need_type(app.config.needs_types, need["type"])

--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -24,7 +24,7 @@ def get_need_type(needs_types: list[ScoreNeedType], directive: str) -> ScoreNeed
     raise ValueError(f"Need type {directive} not found in needs_types")
 
 
-# req-#id: gd_req__req_attr_uid
+# req-Id: gd_req__req_attr_uid
 @local_check
 def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     """
@@ -86,8 +86,8 @@ def _check_options_for_prohibited_words(
                 log.warning_for_need(need, msg)
 
 
-# req-#id: gd_req__req_attr_desc_weak
-# # req-#id: gd_req__requirements_attr_title
+# req-Id: gd_req__req_attr_desc_weak
+# req-Id: gd_req__requirements_attr_title
 @local_check
 def check_for_prohibited_words(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     need_options = get_need_type(app.config.needs_types, need["type"])

--- a/src/extensions/score_metamodel/checks/check_options.py
+++ b/src/extensions/score_metamodel/checks/check_options.py
@@ -91,12 +91,12 @@ def validate_fields(
                 )
 
 
-# req-Id: gd_req__req_attr_type
-# req-Id: gd_req__requirements_attr_security
-# req-Id: gd_req__req_attr_safety
-# req-Id: gd_req__req_attr_status
-# req-Id: gd_req__req_attr_rationale
-# req-Id: gd_req__req_attr_mandatory
+# req-Id: tool_req__docs_req_attr_reqtype
+# req-Id: tool_req__docs_common_attr_security
+# req-Id: tool_req__docs_common_attr_safety
+# req-Id: tool_req__docs_common_attr_status
+# req-Id: tool_req__docs_req_attr_rationale
+# req-Id: tool_req__docs_arch_attr_mandatory
 @local_check
 def check_options(
     app: Sphinx,

--- a/src/extensions/score_metamodel/checks/check_options.py
+++ b/src/extensions/score_metamodel/checks/check_options.py
@@ -14,9 +14,9 @@ import re
 
 from score_metamodel import (
     CheckLogger,
+    ScoreNeedType,
     default_options,
     local_check,
-    ScoreNeedType,
 )
 from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
@@ -91,12 +91,12 @@ def validate_fields(
                 )
 
 
-# req-#id: gd_req__req_attr_type
-# req-#id: gd_req__requirements_attr_security
-# req-#id: gd_req__req_attr_safety
-# req-#id: gd_req__req_attr_status
-# req-#id: gd_req__req_attr_rationale
-# req-#id: gd_req__req_attr_mandatory
+# req-Id: gd_req__req_attr_type
+# req-Id: gd_req__requirements_attr_security
+# req-Id: gd_req__req_attr_safety
+# req-Id: gd_req__req_attr_status
+# req-Id: gd_req__req_attr_rationale
+# req-Id: gd_req__req_attr_mandatory
 @local_check
 def check_options(
     app: Sphinx,

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -931,8 +931,8 @@ needs_extra_links:
 #   - condition: defines the condition that should be checked
 #     - [and / or / xor / not]
 ##############################################################
-# req- Id: gd_req__req_linkage_architecture
-# req- Id: gd_req__req_linkage_safety
+# req-Id: gd_req__req_linkage_architecture
+# req-Id: gd_req__req_linkage_safety
 
 graph_checks:
   # req-Id: tool_req__docs_common_attr_safety_link_check

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -931,8 +931,6 @@ needs_extra_links:
 #   - condition: defines the condition that should be checked
 #     - [and / or / xor / not]
 ##############################################################
-# req-Id: tool_req__docs_dd_feature_flag
-# req-Id: tool_req__docs_req_arch_link_safety_to_arch
 
 graph_checks:
   # req-Id: tool_req__docs_common_attr_safety_link_check

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -931,8 +931,8 @@ needs_extra_links:
 #   - condition: defines the condition that should be checked
 #     - [and / or / xor / not]
 ##############################################################
-# req-Id: gd_req__req_linkage_architecture
-# req-Id: gd_req__req_linkage_safety
+# req-Id: tool_req__docs_dd_feature_flag
+# req-Id: tool_req__docs_req_arch_link_safety_to_arch
 
 graph_checks:
   # req-Id: tool_req__docs_common_attr_safety_link_check

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -225,7 +225,7 @@ def get_current_git_hash(ws_root: Path) -> str:
         raise
 
 
-# req-Id: gd_req__req_attr_impl
+# req-Id: tool_req__docs_dd_link_source_code_link
 def inject_links_into_needs(app: Sphinx, env: BuildEnvironment) -> None:
     """
     'Main' function that facilitates the running of all other functions

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -225,7 +225,7 @@ def get_current_git_hash(ws_root: Path) -> str:
         raise
 
 
-# re-qid: gd_req__req_attr_impl
+# req-Id: gd_req__req_attr_impl
 def inject_links_into_needs(app: Sphinx, env: BuildEnvironment) -> None:
     """
     'Main' function that facilitates the running of all other functions


### PR DESCRIPTION
- Fix source code links strings in code like "# req-qId", "# req- Id", "# req-#id" by the correct one "# req-Id"
- Replace old gd_req source code links by their correct related tool_req based on the Process Requirements Overview table

close: https://github.com/eclipse-score/docs-as-code/issues/201