### PR TITLE
Fix linting errors part 2

### DIFF
--- a/src/extensions/score_draw_uml_funcs/__init__.py
+++ b/src/extensions/score_draw_uml_funcs/__init__.py
@@ -83,6 +83,36 @@ def scripts_directory_hash():
 #       ╰──────────────────────────────────────────────────────────────────────────────╯
 
 
+def _process_interfaces(
+    iface_list: list[str],
+    relation: str,
+    need: dict[str, str],
+    all_needs: dict[str, dict[str, str]],
+    proc_dict: dict[str, str] | dict[str, list[str]],
+    linkage_text: str,
+) -> str:
+    """Helper to process either implemented or used interfaces."""
+    for iface in iface_list:
+        # check for misspelled interface
+        if not all_needs.get(iface, []):
+            logger.info(f"{need}: {relation} {iface} could not be found")
+            continue
+
+        if relation == "implements":
+            if not proc_dict.get(iface, []):
+                linkage_text += (
+                    f"{gen_link_text(need, '-u->', all_needs[iface], 'implements')} \n"
+                )
+                proc_dict[iface] = need["id"]
+        else:  # "uses"
+            if not proc_dict.get(iface, []):
+                proc_dict[iface] = [need["id"]]
+            else:
+                proc_dict[iface].append(need["id"])
+
+    return linkage_text
+
+
 def draw_comp_incl_impl_int(
     need: dict[str, str],
     all_needs: dict[str, dict[str, str]],
@@ -133,36 +163,25 @@ def draw_comp_incl_impl_int(
     local_impl_interfaces = get_interface_from_component(need, "implements", all_needs)
     local_used_interfaces = get_interface_from_component(need, "uses", all_needs)
 
-    # Add all interfaces which are implemented by component to global list
-    # and provide implementation
-    for iface in local_impl_interfaces:
-        # check for misspelled implements
-        if not all_needs.get(iface, []):
-            logger.info(f"{need}: implements {iface} could not be found")
-            continue
+    # Process implemented interfaces
+    linkage_text = _process_interfaces(
+        local_impl_interfaces,
+        "implements",
+        need,
+        all_needs,
+        proc_impl_interfaces,
+        linkage_text,
+    )
 
-        if not proc_impl_interfaces.get(iface, []):
-            linkage_text += f"{
-                gen_link_text(
-                    need,
-                    '-u->',
-                    all_needs[iface],
-                    'implements',
-                )
-                } \n"
-            proc_impl_interfaces[iface] = need["id"]
-
-    # Add all elements which are used by component to global list
-    for iface in local_used_interfaces:
-        # check for misspelled used
-        if not all_needs.get(iface, []):
-            logger.info(f"{need}: uses {iface} could not be found")
-            continue
-
-        if not proc_used_interfaces.get(iface, []):
-            proc_used_interfaces[iface] = [need["id"]]
-        else:
-            proc_used_interfaces[iface].append(need["id"])
+    # Process used interfaces
+    linkage_text = _process_interfaces(
+        local_used_interfaces,
+        "uses",
+        need,
+        all_needs,
+        proc_used_interfaces,
+        linkage_text,
+    )
 
     return structure_text, linkage_text, proc_impl_interfaces, proc_used_interfaces
 
@@ -189,6 +208,68 @@ def draw_impl_interface(
     )
 
     return local_impl_interfaces
+
+
+def _process_impl_interfaces(
+    need: dict[str, str],
+    all_needs: dict[str, dict[str, str]],
+    proc_impl_interfaces: dict[str, str],
+    structure_text: str,
+) -> str:
+    """Handle implemented interfaces outside the boxes."""
+    local_impl_interfaces = draw_impl_interface(need, all_needs, set())
+    # Add all interfaces which are implemented by component to global list
+    # and provide implementation
+    for iface in local_impl_interfaces:
+        # check for misspelled implements
+        if not all_needs.get(iface, []):
+            logger.info(f"{need}: implements {iface} could not be found")
+            continue
+        if not proc_impl_interfaces.get(iface, []):
+            structure_text += gen_interface_element(iface, all_needs, True)
+    return structure_text
+
+
+def _process_used_interfaces(
+    need: dict[str, str],
+    all_needs: dict[str, dict[str, str]],
+    proc_impl_interfaces: dict[str, str],
+    proc_used_interfaces: dict[str, list[str]],
+    local_impl_interfaces: list[str],
+    structure_text: str,
+    linkage_text: str,
+) -> tuple[str, str]:
+    """Handle all interfaces which are used by component."""
+    for iface, comps in proc_used_interfaces.items():
+        if iface not in proc_impl_interfaces:
+            # Add implementing components and modules
+            impl_comp_str = get_impl_comp_from_logic_iface(iface, all_needs)
+            impl_comp = all_needs.get(impl_comp_str[0], {}) if impl_comp_str else ""
+
+            if impl_comp:
+                retval = get_hierarchy_text(impl_comp_str[0], all_needs)
+                structure_text += retval[2]  # module open
+                structure_text += retval[0]  # rest open
+                structure_text += retval[1]  # rest close
+                structure_text += retval[3]  # module close
+                if iface not in local_impl_interfaces:
+                    structure_text += gen_interface_element(iface, all_needs, True)
+                # Draw connection between implementing components and interface
+                linkage_text += f"{
+                    gen_link_text(impl_comp, '-u->', all_needs[iface], 'implements')
+                } \n"
+            else:
+                # Add only interface if component not defined
+                print(f"{iface}: No implementing component defined")
+                structure_text += gen_interface_element(iface, all_needs, True)
+
+        # Interface can be used by multiple components
+        for comp in comps:
+            linkage_text += f"{
+                gen_link_text(all_needs[comp], '-d[#green]->', all_needs[iface], 'uses')
+            } \n"
+
+    return structure_text, linkage_text
 
 
 def draw_module(
@@ -254,17 +335,9 @@ def draw_module(
 
     # Draw all implemented interfaces outside the boxes
     local_impl_interfaces = draw_impl_interface(need, all_needs, set())
-
-    # Add all interfaces which are implemented by component to global list
-    # and provide implementation
-    for iface in local_impl_interfaces:
-        # check for misspelled implements
-        if not all_needs.get(iface, []):
-            logger.info(f"{need}: implements {iface} could not be found")
-            continue
-
-        if not proc_impl_interfaces.get(iface, []):
-            structure_text += gen_interface_element(iface, all_needs, True)
+    structure_text = _process_impl_interfaces(
+        need, all_needs, proc_impl_interfaces, structure_text
+    )
 
     # Draw outer module
     structure_text += f"{gen_struct_element('package', need)}  {{\n"
@@ -272,21 +345,17 @@ def draw_module(
     # Draw inner components recursively
     for need_inc in need.get("includes", []):
         curr_need = all_needs.get(need_inc, {})
-
         # check for misspelled include
         if not curr_need:
             logger.info(f"{need}: include with id {need_inc} could not be found")
             continue
-
         if curr_need["type"] not in ["comp_arc_sta", "mod_view_sta"]:
             continue
-
         sub_structure, sub_linkage, proc_impl_interfaces, proc_used_interfaces = (
             draw_comp_incl_impl_int(
                 curr_need, all_needs, proc_impl_interfaces, proc_used_interfaces
             )
         )
-
         structure_text += sub_structure
         linkage_text += sub_linkage
 
@@ -294,45 +363,15 @@ def draw_module(
     structure_text += f"}} /' {need['title']} '/ \n\n"
 
     # Add all interfaces which are used by component
-    for iface, comps in proc_used_interfaces.items():
-        if iface not in proc_impl_interfaces:
-            # Add implementing components and modules
-            impl_comp_str = get_impl_comp_from_logic_iface(iface, all_needs)
-
-            impl_comp = all_needs.get(impl_comp_str[0], {}) if impl_comp_str else ""
-
-            if impl_comp:
-                retval = get_hierarchy_text(impl_comp_str[0], all_needs)
-                structure_text += retval[2]  # module open
-                structure_text += retval[0]  # rest open
-
-                structure_text += retval[1]  # rest close
-                structure_text += retval[3]  # module close
-                if iface not in local_impl_interfaces:
-                    structure_text += gen_interface_element(iface, all_needs, True)
-
-                # Draw connection between implementing components and interface
-                linkage_text += f"{gen_link_text(
-                                    impl_comp,
-                                    '-u->',
-                                    all_needs[iface],
-                                    'implements'
-                                )} \n"
-
-            else:
-                # Add only interface if component not defined
-                print(f"{iface}: No implementing component defined")
-                structure_text += gen_interface_element(iface, all_needs, True)
-
-        # Interface can be used by multiple components
-        for comp in comps:
-            # Draw connection between used interfaces and components
-            linkage_text += f"{gen_link_text(
-                                all_needs[comp],
-                                '-d[#green]->',
-                                all_needs[iface],
-                                'uses'
-                            )} \n"
+    structure_text, linkage_text = _process_used_interfaces(
+        need,
+        all_needs,
+        proc_impl_interfaces,
+        proc_used_interfaces,
+        local_impl_interfaces,
+        structure_text,
+        linkage_text,
+    )
 
     # Remove duplicate links
     linkage_text = "\n".join(set(linkage_text.split("\n"))) + "\n"
@@ -348,6 +387,98 @@ def draw_module(
 class draw_full_feature:
     def __repr__(self):
         return "draw_full_feature" + " in " + scripts_directory_hash()
+
+    def _collect_interfaces_and_modules(
+        self,
+        need: dict[str, str],
+        all_needs: dict[str, dict[str, str]],
+        interfacelist: list[str],
+        impl_comp: dict[str, str],
+        proc_modules: list[str],
+        proc_impl_interfaces: dict[str, str],
+        proc_used_interfaces: dict[str, list[str]],
+        structure_text: str,
+        link_text: str,
+    ) -> tuple[
+        str, str, dict[str, str], dict[str, list[str]], dict[str, str], list[str]
+    ]:
+        """Process interfaces and load modules for implementation."""
+        for iface in interfacelist:
+            if all_needs.get(iface):
+                if iface:
+                    comps = get_impl_comp_from_logic_iface(iface, all_needs)
+                    if comps:
+                        impl_comp[iface] = comps[0]
+
+                if imcomp := impl_comp.get(iface, {}):
+                    module = get_module(imcomp, all_needs)
+                    # FIXME: sometimes module is empty, then the following code fails
+                    if not module:
+                        logger.info(
+                            f"FIXME: {need['id']}: "
+                            f"Module for interface {iface} -> {imcomp} is empty."
+                        )
+                        continue
+
+                    if module not in proc_modules:
+                        tmp, link_text, proc_impl_interfaces, proc_used_interfaces = (
+                            draw_module(
+                                all_needs[module],
+                                all_needs,
+                                proc_impl_interfaces,
+                                proc_used_interfaces,
+                            )
+                        )
+                        structure_text += tmp
+                        proc_modules.append(module)
+            else:
+                logger.info(f"{need}: Interface {iface} could not be found")
+                continue
+        return (
+            structure_text,
+            link_text,
+            proc_impl_interfaces,
+            proc_used_interfaces,
+            impl_comp,
+            proc_modules,
+        )
+
+    def _build_links(
+        self,
+        need: dict[str, str],
+        all_needs: dict[str, dict[str, str]],
+        interfacelist: list[str],
+        impl_comp: dict[str, str],
+        link_text: str,
+    ) -> str:
+        """Add actor-interface and interface-component relations."""
+        for iface in interfacelist:
+            if imcomp := impl_comp.get(iface):
+                # Add relation between Actor and Interfaces
+                link_text += f"{
+                    gen_link_text(
+                        {'id': 'Feature_User'}, '-d->', all_needs[iface], 'use'
+                    )
+                } \n"
+
+                # Add relation between interface and component
+                if imcomp := impl_comp.get(iface):
+                    link_text += f"{
+                        gen_link_text(
+                            all_needs[imcomp],
+                            '-u->',
+                            all_needs[iface],
+                            'implements',
+                        )
+                    } \n"
+                else:
+                    logger.info(
+                        f"Interface {iface} is not implemented by any component"
+                    )
+            else:
+                logger.info(f"{need}: Interface {iface} could not be found")
+                continue
+        return link_text
 
     def __call__(
         self, need: dict[str, str], all_needs: dict[str, dict[str, str]]
@@ -375,70 +506,33 @@ class draw_full_feature:
             if iface not in interfacelist:
                 interfacelist.append(iface)
 
-        for iface in interfacelist:
-            if all_needs.get(iface):
-                if iface:
-                    comps = get_impl_comp_from_logic_iface(iface, all_needs)
-
-                    if comps:
-                        impl_comp[iface] = comps[0]
-
-                if imcomp := impl_comp.get(iface, {}):
-                    module = get_module(imcomp, all_needs)
-
-                    # FIXME: sometimes module is empty, then the following code fails
-                    if not module:
-                        logger.info(
-                            f"FIXME: {need['id']}: "
-                            f"Module for interface {iface} -> {imcomp} is empty."
-                        )
-                        continue
-
-                    if module not in proc_modules:
-                        tmp, link_text, proc_impl_interfaces, proc_used_interfaces = (
-                            draw_module(
-                                all_needs[module],
-                                all_needs,
-                                proc_impl_interfaces,
-                                proc_used_interfaces,
-                            )
-                        )
-                        structure_text += tmp
-                        proc_modules.append(module)
-
-            else:
-                logger.info(f"{need}: Interface {iface} could not be found")
-                continue
+        # Process interfaces and collect required modules
+        (
+            structure_text,
+            link_text,
+            proc_impl_interfaces,
+            proc_used_interfaces,
+            impl_comp,
+            proc_modules,
+        ) = self._collect_interfaces_and_modules(
+            need,
+            all_needs,
+            interfacelist,
+            impl_comp,
+            proc_modules,
+            proc_impl_interfaces,
+            proc_used_interfaces,
+            structure_text,
+            link_text,
+        )
 
         # Close Package
         # structure_text += f"}} /' {need['title']}  '/ \n\n"
 
-        for iface in interfacelist:
-            if imcomp := impl_comp.get(iface):
-                # Add relation between Actor and Interfaces
-                link_text += f"{
-                    gen_link_text(
-                        {'id': 'Feature_User'}, '-d->', all_needs[iface], 'use'
-                    )
-                } \n"
-
-                # Add relation between interface and component
-                if imcomp := impl_comp.get(iface):
-                    link_text += f"{
-                        gen_link_text(
-                            all_needs[imcomp],
-                            '-u->',
-                            all_needs[iface],
-                            'implements',
-                        )
-                    } \n"
-                else:
-                    logger.info(
-                        f"Interface {iface} is not implemented by any component"
-                    )
-            else:
-                logger.info(f"{need}: Interface {iface} could not be found")
-                continue
+        # Build all links between actor, interfaces, and components
+        link_text = self._build_links(
+            need, all_needs, interfacelist, impl_comp, link_text
+        )
 
         # Remove duplicate links
         link_text = "\n".join(set(link_text.split("\n"))) + "\n"

--- a/src/extensions/score_draw_uml_funcs/__init__.py
+++ b/src/extensions/score_draw_uml_funcs/__init__.py
@@ -149,7 +149,7 @@ def draw_comp_incl_impl_int(
                     all_needs[iface],
                     'implements',
                 )
-            } \n"
+                } \n"
             proc_impl_interfaces[iface] = need["id"]
 
     # Add all elements which are used by component to global list
@@ -312,7 +312,12 @@ def draw_module(
                     structure_text += gen_interface_element(iface, all_needs, True)
 
                 # Draw connection between implementing components and interface
-                linkage_text += f"{gen_link_text(impl_comp, '-u->', all_needs[iface], 'implements')} \n"
+                linkage_text += f"{gen_link_text(
+                                    impl_comp,
+                                    '-u->',
+                                    all_needs[iface],
+                                    'implements'
+                                )} \n"
 
             else:
                 # Add only interface if component not defined
@@ -322,7 +327,12 @@ def draw_module(
         # Interface can be used by multiple components
         for comp in comps:
             # Draw connection between used interfaces and components
-            linkage_text += f"{gen_link_text(all_needs[comp], '-d[#green]->', all_needs[iface], 'uses')} \n"
+            linkage_text += f"{gen_link_text(
+                                all_needs[comp],
+                                '-d[#green]->',
+                                all_needs[iface],
+                                'uses'
+                            )} \n"
 
     # Remove duplicate links
     linkage_text = "\n".join(set(linkage_text.split("\n"))) + "\n"
@@ -366,7 +376,7 @@ class draw_full_feature:
                 interfacelist.append(iface)
 
         for iface in interfacelist:
-            if iface_need := all_needs.get(iface):
+            if all_needs.get(iface):
                 if iface:
                     comps = get_impl_comp_from_logic_iface(iface, all_needs)
 

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -23,13 +23,6 @@ from sphinx_needs import logging
 from sphinx_needs.config import NeedType
 from sphinx_needs.data import NeedsInfoType, NeedsView, SphinxNeedsData
 
-from src.helper_lib import (
-    find_git_root,
-    find_ws_root,
-    get_current_git_hash,
-    get_github_repo_info,
-)
-
 from .external_needs import connect_external_needs
 from .log import CheckLogger
 

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import importlib
-import json
 import os
 import pkgutil
 from collections.abc import Callable

--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -70,11 +70,11 @@ def check_id_length(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     if parts[1] == "example_feature":
         max_lenght += 17  # _example_feature_
     if len(need["id"]) > max_lenght:
-        length =0
-        if 'example_feature' not in need['id'] :
-            length = len(need['id'])
+        length = 0
+        if "example_feature" not in need["id"]:
+            length = len(need["id"])
         else:
-            length = len(need['id']) - 17
+            length = len(need["id"]) - 17
         msg = (
             f"exceeds the maximum allowed length of 45 characters "
             "(current length: "

--- a/src/extensions/score_metamodel/checks/attributes_format.py
+++ b/src/extensions/score_metamodel/checks/attributes_format.py
@@ -70,10 +70,15 @@ def check_id_length(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     if parts[1] == "example_feature":
         max_lenght += 17  # _example_feature_
     if len(need["id"]) > max_lenght:
+        length =0
+        if 'example_feature' not in need['id'] :
+            length = len(need['id'])
+        else:
+            length = len(need['id']) - 17
         msg = (
             f"exceeds the maximum allowed length of 45 characters "
             "(current length: "
-            f"{len(need['id']) if 'example_feature' not in need['id'] else len(need['id']) - 17})."
+            f"{length})."
         )
         log.warning_for_option(need, "id", msg)
 
@@ -82,7 +87,7 @@ def _check_options_for_prohibited_words(
     prohibited_word_checks: ProhibitedWordCheck, need: NeedsInfoType, log: CheckLogger
 ):
     options: list[str] = [
-        x for x in prohibited_word_checks.option_check.keys() if x != "types"
+        x for x in prohibited_word_checks.option_check if x != "types"
     ]
     for option in options:
         forbidden_words = prohibited_word_checks.option_check[option]

--- a/src/extensions/score_metamodel/checks/check_options.py
+++ b/src/extensions/score_metamodel/checks/check_options.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import re
+from os import error
 
 from score_metamodel import (
     CheckLogger,
@@ -41,7 +42,7 @@ def _normalize_values(raw_value: str | list[str] | None) -> list[str]:
         return [raw_value]
     if isinstance(raw_value, list) and all(isinstance(v, str) for v in raw_value):
         return raw_value
-    raise ValueError("unexpected types")
+    raise ValueError
 
 
 def _validate_value_pattern(
@@ -88,9 +89,13 @@ def validate_fields(
                     need, f"is missing required {field_type}: `{field}`."
                 )
             continue  # Skip empty optional fields
-
-        values = _normalize_values(raw_value)
-
+        try:
+            values = _normalize_values(raw_value)
+        except ValueError as err:
+            raise ValueError(
+                f"An Attribute inside need {need['id']} is "
+                "not of type str. Only Strings are allowed"
+            ) from err
         # The filter ensures that the function is only called when needed.
         for value in values:
             if allowed_prefixes:

--- a/src/extensions/score_metamodel/checks/check_options.py
+++ b/src/extensions/score_metamodel/checks/check_options.py
@@ -35,11 +35,13 @@ def get_need_type(needs_types: list[ScoreNeedType], directive: str) -> ScoreNeed
 
 def _normalize_values(raw_value: str | list[str] | None) -> list[str]:
     """Normalize a raw value into a list of strings."""
+    if raw_value is None:
+        return []
     if isinstance(raw_value, str):
         return [raw_value]
     if isinstance(raw_value, list) and all(isinstance(v, str) for v in raw_value):
         return raw_value
-    return [str(raw_value)]
+    raise ValueError("unexpected types")
 
 
 def _validate_value_pattern(

--- a/src/extensions/score_metamodel/tests/test_check_options.py
+++ b/src/extensions/score_metamodel/tests/test_check_options.py
@@ -156,7 +156,7 @@ class TestCheckOptions:
             target_id="wf_req__001",
             id="wf_req__001",
             type="workflow",
-            some_invalid_option=42,
+            some_invalid_option="42",
             docname=None,
             lineno=None,
         )

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -66,7 +66,8 @@ def setup_once(app: Sphinx, config: Config):
     LOGGER.debug(f"DEBUG: Git root is {find_git_root()}")
 
     # Run only for local files!
-    # ws_root is not set when running on any on bazel run command repositories (dependencies)
+    # ws_root is not set when running on any on bazel run
+    # command repositories (dependencies)
     ws_root = find_ws_root()
     if not ws_root:
         return
@@ -196,12 +197,6 @@ def get_git_root(git_root: Path = Path()) -> Path:
     else:
         passed_git_root = git_root
     return passed_git_root
-
-
-def get_github_base_url(git_root: Path = Path()) -> str:
-    passed_git_root = get_git_root(git_root)
-    repo_info = get_github_repo_info(passed_git_root)
-    return f"https://github.com/{repo_info}"
 
 
 def get_github_link(

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -271,7 +271,7 @@ def inject_links_into_needs(app: Sphinx, env: BuildEnvironment) -> None:
             need_as_dict = cast(dict[str, object], need)
 
             need_as_dict["source_code_link"] = ", ".join(
-                f"{get_github_link(n)}<>{n.file}:{n.line}" for n in needlinks
+                f"{get_github_link(None, n)}<>{n.file}:{n.line}" for n in needlinks
             )
 
             # NOTE: Removing & adding the need is important to make sure

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -15,7 +15,6 @@
 source code links from a JSON file and add them to the needs.
 """
 
-import subprocess
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
@@ -39,6 +38,7 @@ from src.helper_lib import (
     find_git_root,
     find_ws_root,
     get_current_git_hash,
+    get_github_base_url,
 )
 
 LOGGER = get_logger(__name__)
@@ -156,63 +156,6 @@ def get_github_link(needlink: NeedLink | None = None) -> str:
     base_url = get_github_base_url()
     current_hash = get_current_git_hash(passed_git_root)
     return f"{base_url}/blob/{current_hash}/{needlink.file}#L{needlink.line}"
-
-
-def parse_git_output(str_line: str) -> str:
-    if len(str_line.split()) < 2:
-        LOGGER.warning(
-            "Got wrong input line from 'get_github_repo_info'. "
-            f"Input: {str_line}."
-            "Expected example: 'origin git@github.com:user/repo.git'"
-        )
-        return ""
-    url = str_line.split()[1]  # Get the URL part
-    # Handle SSH format (git@github.com:user/repo.git)
-    path = (
-        url.split(":")[1] if url.startswith("git@") else "/".join(url.split("/")[3:])
-    )  # Get part after github.com/
-    return path.replace(".git", "")
-
-
-def get_github_repo_info(git_root_cwd: Path) -> str:
-    process = subprocess.run(
-        ["git", "remote", "-v"], capture_output=True, text=True, cwd=git_root_cwd
-    )
-    repo = ""
-    for line in process.stdout.split("\n"):
-        if "origin" in line and "(fetch)" in line:
-            repo = parse_git_output(line)
-            break
-    else:
-        # If we do not find 'origin' we just take the first line
-        LOGGER.info(
-            "Did not find origin remote name. "
-            "Will now take first result from: 'git remote -v'"
-        )
-        repo = parse_git_output(process.stdout.split("\n")[0])
-    assert repo != "", (
-        "Remote repository is not defined. Make sure you have a remote set. "
-        "Check this via 'git remote -v'"
-    )
-    return repo
-
-
-def get_git_root(git_root: Path = Path()) -> Path:
-    # This is kinda ugly, doing this to reduce type errors.
-    # There might be a nicer way to do this
-    if git_root == Path():
-        passed_git_root = find_git_root()
-        if passed_git_root is None:
-            return Path()
-    else:
-        passed_git_root = git_root
-    return passed_git_root
-
-
-def get_github_base_url(git_root: Path = Path()) -> str:
-    passed_git_root = get_git_root(git_root)
-    repo_info = get_github_repo_info(passed_git_root)
-    return f"https://github.com/{repo_info}"
 
 
 # req-Id: tool_req__docs_dd_link_source_code_link

--- a/src/extensions/score_source_code_linker/__init__.py
+++ b/src/extensions/score_source_code_linker/__init__.py
@@ -39,7 +39,6 @@ from src.helper_lib import (
     find_git_root,
     find_ws_root,
     get_current_git_hash,
-    get_github_base_url,
 )
 
 LOGGER = get_logger(__name__)
@@ -197,6 +196,12 @@ def get_git_root(git_root: Path = Path()) -> Path:
     else:
         passed_git_root = git_root
     return passed_git_root
+
+
+def get_github_base_url(git_root: Path = Path()) -> str:
+    passed_git_root = get_git_root(git_root)
+    repo_info = get_github_repo_info(passed_git_root)
+    return f"https://github.com/{repo_info}"
 
 
 def get_github_link(

--- a/src/extensions/score_source_code_linker/tests/test_requirement_links.py
+++ b/src/extensions/score_source_code_linker/tests/test_requirement_links.py
@@ -416,7 +416,7 @@ def test_get_current_git_hash(git_repo):
 
 def test_get_current_git_hash_invalid_repo(temp_dir):
     """Test getting git hash from invalid repository."""
-    with pytest.raises(Exception):
+    with pytest.raises(subprocess.CalledProcessError):
         get_current_git_hash(temp_dir)
 
 
@@ -519,7 +519,7 @@ def test_group_by_need_and_find_need_integration(sample_needlinks):
     )
 
     # Test finding needs for each group
-    for need_id, links in grouped.items():
+    for need_id in grouped:
         found_need = find_need(all_needs, need_id, ["PREFIX_"])
         if need_id in ["TREQ_ID_1", "TREQ_ID_2"]:
             assert found_need is not None

--- a/src/extensions/score_source_code_linker/tests/test_source_link.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_link.py
@@ -171,9 +171,9 @@ def sphinx_app_setup(
         finally:
             # Try to restore original directory, but don't fail if it doesn't exist
             if original_cwd is not None and "original_cwd" in locals():
-                    # Original directory might not exist anymore in Bazel sandbox
-                    with contextlib.suppress(FileNotFoundError, OSError):
-                        os.chdir(original_cwd)
+                # Original directory might not exist anymore in Bazel sandbox
+                with contextlib.suppress(FileNotFoundError, OSError):
+                    os.chdir(original_cwd)
 
     return _create_app
 

--- a/src/extensions/score_source_code_linker/tests/test_source_link.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_link.py
@@ -170,7 +170,7 @@ def sphinx_app_setup(
             )
         finally:
             # Try to restore original directory, but don't fail if it doesn't exist
-            if original_cwd is not None and "original_cwd" in locals():
+            if original_cwd is not None:
                 # Original directory might not exist anymore in Bazel sandbox
                 with contextlib.suppress(FileNotFoundError, OSError):
                     os.chdir(original_cwd)

--- a/src/find_runfiles/test_find_runfiles.py
+++ b/src/find_runfiles/test_find_runfiles.py
@@ -39,7 +39,10 @@ def test_run_incremental():
             env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
             git_root="/workspaces/process",
         )
-        == "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles"
+        == (
+            "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
+            "incremental.runfiles"
+        )
     )
 
     # in conf.py:
@@ -50,7 +53,10 @@ def test_run_incremental():
             env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
             git_root="/workspaces/process",
         )
-        == "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles"
+        == (
+            "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
+            "incremental.runfiles"
+        )
     )
 
 
@@ -90,5 +96,8 @@ def test3():
             env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/other-docs/incremental.runfiles",
             git_root="/workspaces/process",
         )
-        == "/workspaces/process/bazel-out/k8-fastbuild/bin/other-docs/incremental.runfiles"
+        == (
+            "/workspaces/process/bazel-out/k8-fastbuild/bin/other-docs/"
+            "incremental.runfiles"
+        )
     )

--- a/src/find_runfiles/test_find_runfiles.py
+++ b/src/find_runfiles/test_find_runfiles.py
@@ -32,31 +32,25 @@ def get_runfiles_dir_impl(
 def test_run_incremental():
     """bazel run //process-docs:incremental"""
     # in incremental.py:
-    assert (
-        get_runfiles_dir_impl(
-            cwd="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles/_main",
-            conf_dir="process-docs",
-            env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
-            git_root="/workspaces/process",
-        )
-        == (
-            "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
-            "incremental.runfiles"
-        )
+    assert get_runfiles_dir_impl(
+        cwd="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles/_main",
+        conf_dir="process-docs",
+        env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
+        git_root="/workspaces/process",
+    ) == (
+        "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
+        "incremental.runfiles"
     )
 
     # in conf.py:
-    assert (
-        get_runfiles_dir_impl(
-            cwd="/workspaces/process/process-docs",
-            conf_dir="process-docs",
-            env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
-            git_root="/workspaces/process",
-        )
-        == (
-            "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
-            "incremental.runfiles"
-        )
+    assert get_runfiles_dir_impl(
+        cwd="/workspaces/process/process-docs",
+        conf_dir="process-docs",
+        env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/process-docs/incremental.runfiles",
+        git_root="/workspaces/process",
+    ) == (
+        "/workspaces/process/bazel-out/k8-fastbuild/bin/process-docs/"
+        "incremental.runfiles"
     )
 
 
@@ -89,15 +83,11 @@ def test_esbonio_old():
 def test3():
     # docs named differently, just to make sure nothing is hardcoded
     # bazel run //other-docs:incremental
-    assert (
-        get_runfiles_dir_impl(
-            cwd="/workspaces/process/other-docs",
-            conf_dir="other-docs",
-            env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/other-docs/incremental.runfiles",
-            git_root="/workspaces/process",
-        )
-        == (
-            "/workspaces/process/bazel-out/k8-fastbuild/bin/other-docs/"
-            "incremental.runfiles"
-        )
+    assert get_runfiles_dir_impl(
+        cwd="/workspaces/process/other-docs",
+        conf_dir="other-docs",
+        env_runfiles="/home/vscode/.cache/bazel/_bazel_vscode/6084288f00f33db17acb4220ce8f1999/execroot/_main/bazel-out/k8-fastbuild/bin/other-docs/incremental.runfiles",
+        git_root="/workspaces/process",
+    ) == (
+        "/workspaces/process/bazel-out/k8-fastbuild/bin/other-docs/incremental.runfiles"
     )

--- a/src/helper_lib/test_helper_lib.py
+++ b/src/helper_lib/test_helper_lib.py
@@ -42,7 +42,7 @@ def test_git_operations_with_no_commits(temp_dir):
 
     os.chdir(Path(git_dir).absolute())
     # Should raise an exception when trying to get hash
-    with pytest.raises(Exception):
+    with pytest.raises(subprocess.CalledProcessError):
         get_current_git_hash(git_dir)
 
 

--- a/src/tests/test_consumer.py
+++ b/src/tests/test_consumer.py
@@ -211,7 +211,7 @@ def parse_bazel_output(BR: BuildOutput, pytestconfig) -> BuildOutput:
     split_warnings = [x for x in err_lines if "WARNING: " in x]
     warning_dict: dict[str, list[str]] = defaultdict(list)
 
-    if pytestconfig.get_verbosity() >= 2 and  os.getenv("CI"):
+    if pytestconfig.get_verbosity() >= 2 and os.getenv("CI"):
         print("[DEBUG] Raw warnings in CI:")
         for i, warning in enumerate(split_warnings):
             print(f"[DEBUG] Warning {i}: {repr(warning)}")

--- a/src/tests/test_consumer.py
+++ b/src/tests/test_consumer.py
@@ -118,6 +118,7 @@ def sphinx_base_dir(tmp_path_factory: TempPathFactory, pytestconfig) -> Path:
         temp_dir = tmp_path_factory.mktemp("testing_dir")
         print(f"[blue]Using temporary directory: {temp_dir}[/blue]")
         return temp_dir
+
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[green]Using persistent cache directory: {CACHE_DIR}[/green]")
     return CACHE_DIR
@@ -210,11 +211,10 @@ def parse_bazel_output(BR: BuildOutput, pytestconfig) -> BuildOutput:
     split_warnings = [x for x in err_lines if "WARNING: " in x]
     warning_dict: dict[str, list[str]] = defaultdict(list)
 
-    if pytestconfig.get_verbosity() >= 2:
-        if os.getenv("CI"):
-            print("[DEBUG] Raw warnings in CI:")
-            for i, warning in enumerate(split_warnings):
-                print(f"[DEBUG] Warning {i}: {repr(warning)}")
+    if pytestconfig.get_verbosity() >= 2 and  os.getenv("CI"):
+        print("[DEBUG] Raw warnings in CI:")
+        for i, warning in enumerate(split_warnings):
+            print(f"[DEBUG] Warning {i}: {repr(warning)}")
 
     for raw_warning in split_warnings:
         # In the CLI we seem to have some ansi codes in the warnings.
@@ -489,6 +489,9 @@ def setup_test_environment(sphinx_base_dir, pytestconfig):
 
     if verbosity >= 2:
         print(f"[DEBUG] git_root: {git_root}")
+
+    if git_root is None:
+        raise ValueError("Git root was None")
 
     # Get GitHub URL and current hash for git override
 

--- a/src/tests/test_consumer.py
+++ b/src/tests/test_consumer.py
@@ -510,6 +510,7 @@ def setup_test_environment(sphinx_base_dir, pytestconfig):
                 debug_print(f"Removed existing symlink: {dest}")
             elif dest.is_dir():
                 import shutil
+
                 shutil.rmtree(dest)
                 debug_print(f"Removed existing directory: {dest}")
         dest.symlink_to(target)


### PR DESCRIPTION
<p>
This PR resolves a total of <strong>32 remaining linting errors</strong>, addressing various code quality and style improvements. 
The following changes were made:
</p>

<ul>
  <li>Fixed <strong>line length violations</strong> to comply with style guidelines.</li>
  <li>Removed unnecessary <code>f</code> prefix from strings where no interpolation occurs (e.g., <code>f"hello"</code> → <code>"hello"</code>).</li>
  <li>Eliminated redundant <code>else</code> blocks following a <code>return</code> statement.</li>
  <li>Removed unnecessary default mode argument <code>"r"</code> when opening files 
      (e.g., <code>open("module.bazel", "r")</code> → <code>open("module.bazel")</code>).</li>
  <li>Replaced <code>assert False</code> statements with more descriptive and proper error handling.</li>
  <li>Removed redundant <code>else</code> after <code>continue</code> statements.</li>
  <li>Used <code>contextlib.suppress(FileNotFoundError)</code> instead of 
      <code>try/except/pass</code> for cleaner exception handling.</li>
  <li>Fixed blind <code>assert Exception</code> usage by specifying explicit exception types.</li>
  <li>Moved function calls out of default parameter values and into the function body.</li>
  <li>Refactored several functions to <strong>reduce cyclomatic complexity</strong> 
      while maintaining original functionality and comments.</li>
</ul>

<p>
<b>Note 1:</b> All builds, documentation generation, and tests run successfully after these changes.</b>
<b>Note 2:</b> We got a new list of 66 different errors and warnings after solving the initial first list .</b>
</p>

close: https://github.com/eclipse-score/docs-as-code/issues/205