### PR TITLE
Improve new checks logs visibility

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -144,9 +144,11 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
         log.warning("Some needs have issues. See the log for more information.")
 
     if log.has_infos:
+        log.flush_new_checks()
         log.info(
-            "Some needs have issues related to the new checks. "
-            "See the log for more information."
+            "\n\nThese new_checks warnings are displayed as info for now. "
+            "They will become real warnings in the future. "
+            "Please fix them as soon as possible.\n"
         )
         # TODO: exit code
 

--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -141,12 +141,12 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
         check(app, needs_all_needs, log)
 
     if log.has_warnings:
-        log.warning("Some needs have issues. See the log for more information.")
+        logger.warning("Some needs have issues. See the log for more information.")
 
     if log.has_infos:
         log.flush_new_checks()
-        log.info(
-            "\n\nThese new_checks warnings are displayed as info for now. "
+        logger.info(
+            "\n\nThese next warnings are displayed as info statements for now. "
             "They will become real warnings in the future. "
             "Please fix them as soon as possible.\n"
         )

--- a/src/extensions/score_metamodel/log.py
+++ b/src/extensions/score_metamodel/log.py
@@ -11,14 +11,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import os
-from typing import Any, Optional, Union
+from typing import Any
 
 from docutils.nodes import Node
 from sphinx_needs import logging
 from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.logging import SphinxLoggerAdapter
 
-Location = Union[str, tuple[Optional[str], Optional[int]], Node, None]
+Location = str | tuple[str | None, int | None] | Node | None
 NewCheck = tuple[str, Location]
 logger = logging.get_logger(__name__)
 
@@ -65,7 +65,7 @@ class CheckLogger:
     def _log_message(
         self,
         msg: str,
-        location: None | str | tuple[str | None, int | None] | Node = None,
+        location: Location,
         is_new_check: bool = False,
     ):
         if is_new_check:
@@ -78,14 +78,14 @@ class CheckLogger:
     def info(
         self,
         msg: str,
-        location: None | str | tuple[str | None, int | None] | Node = None,
+        location: Location,
     ):
         self._log.info(msg, type="score_metamodel", location=location)
 
     def warning(
         self,
         msg: str,
-        location: None | str | tuple[str | None, int | None] | Node = None,
+        location: Location,
     ):
         self._log.warning(msg, type="score_metamodel", location=location)
 
@@ -98,9 +98,9 @@ class CheckLogger:
         return self._info_count > 0
 
     def flush_new_checks(self):
-        """Log all new-check messages together once."""
+        """Log all new-check messages together at once."""
 
-        def make_header_line(text: str, width: int = 120) -> str:
+        def make_header_line(text: str, width: int = 80) -> str:
             """Center a header inside '=' padding so line length stays fixed."""
             text = f" {text} "
             return text.center(width, "=")
@@ -109,7 +109,7 @@ class CheckLogger:
             return
 
         info_header = make_header_line("[INFO MESSAGE]")
-        separator = "=" * 120
+        separator = "=" * 80
         warning_header = make_header_line(
             f"[New Checks] has {len(self._new_checks)} warnings"
         )

--- a/src/extensions/score_metamodel/log.py
+++ b/src/extensions/score_metamodel/log.py
@@ -11,11 +11,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import os
-from typing import Any
+from typing import Any, Optional, Union
 
 from docutils.nodes import Node
+from sphinx_needs import logging
 from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.logging import SphinxLoggerAdapter
+
+Location = Union[str, tuple[Optional[str], Optional[int]], Node, None]
+NewCheck = tuple[str, Location]
+logger = logging.get_logger(__name__)
 
 
 class CheckLogger:
@@ -24,6 +29,7 @@ class CheckLogger:
         self._info_count = 0
         self._warning_count = 0
         self._prefix = prefix
+        self._new_checks: list[NewCheck] = []
 
     @staticmethod
     def _location(need: NeedsInfoType, prefix: str):
@@ -43,43 +49,31 @@ class CheckLogger:
         return None
 
     def warning_for_option(
-        self, need: NeedsInfoType, option: str, msg: str, new_check: bool = False
+        self, need: NeedsInfoType, option: str, msg: str, is_new_check: bool = False
     ):
         full_msg = f"{need['id']}.{option} ({need.get(option, None)}): {msg}"
         location = CheckLogger._location(need, self._prefix)
-        self._log_message(full_msg, location, new_check)
+        self._log_message(full_msg, location, is_new_check)
 
-    def warning_for_need(self, need: NeedsInfoType, msg: str, new_check: bool = False):
+    def warning_for_need(
+        self, need: NeedsInfoType, msg: str, is_new_check: bool = False
+    ):
         full_msg = f"{need['id']}: {msg}"
         location = CheckLogger._location(need, self._prefix)
-        self._log_message(full_msg, location, new_check)
+        self._log_message(full_msg, location, is_new_check)
 
     def _log_message(
         self,
         msg: str,
         location: None | str | tuple[str | None, int | None] | Node = None,
-        is_info: bool = False,
+        is_new_check: bool = False,
     ):
-        def make_header_line(text: str, width: int = 120) -> str:
-            """Center a header inside '=' padding so line length stays fixed."""
-            text = f" {text} "
-            return text.center(width, "=")
-
-        if is_info:
-            info_header = make_header_line("[INFO MESSAGE]")
-            warning_header = make_header_line("[New Check Warning]")
-
-            msg = (
-                f"\n\n{info_header}\n\n"
-                f"{'=' * len(info_header)}\n\n"
-                f"{warning_header}\n\n"
-                f"{msg}\n"
-                "Please fix this warning related to the new check "
-                "before the release of the next version of Docs-As-Code.\n"
-            )
-            self.info(msg, location)
+        if is_new_check:
+            self._new_checks.append((msg, location))
+            self._info_count += 1
         else:
             self.warning(msg, location)
+            self._warning_count += 1
 
     def info(
         self,
@@ -87,7 +81,6 @@ class CheckLogger:
         location: None | str | tuple[str | None, int | None] | Node = None,
     ):
         self._log.info(msg, type="score_metamodel", location=location)
-        self._info_count += 1
 
     def warning(
         self,
@@ -95,7 +88,6 @@ class CheckLogger:
         location: None | str | tuple[str | None, int | None] | Node = None,
     ):
         self._log.warning(msg, type="score_metamodel", location=location)
-        self._warning_count += 1
 
     @property
     def has_warnings(self):
@@ -104,3 +96,27 @@ class CheckLogger:
     @property
     def has_infos(self):
         return self._info_count > 0
+
+    def flush_new_checks(self):
+        """Log all new-check messages together once."""
+
+        def make_header_line(text: str, width: int = 120) -> str:
+            """Center a header inside '=' padding so line length stays fixed."""
+            text = f" {text} "
+            return text.center(width, "=")
+
+        if not self._new_checks:
+            return
+
+        info_header = make_header_line("[INFO MESSAGE]")
+        separator = "=" * 120
+        warning_header = make_header_line(
+            f"[New Checks] has {len(self._new_checks)} warnings"
+        )
+
+        logger.info(info_header)
+        logger.info(separator)
+        logger.info(warning_header)
+
+        for msg, location in self._new_checks:
+            self.info(msg, location)

--- a/src/extensions/score_metamodel/log.py
+++ b/src/extensions/score_metamodel/log.py
@@ -60,10 +60,22 @@ class CheckLogger:
         location: None | str | tuple[str | None, int | None] | Node = None,
         is_info: bool = False,
     ):
+        def make_header_line(text: str, width: int = 120) -> str:
+            """Center a header inside '=' padding so line length stays fixed."""
+            text = f" {text} "
+            return text.center(width, "=")
+
         if is_info:
-            msg += (
-                "\nPlease fix this warning related to the new check "
-                "before the release of the next version of Docs-As-Code."
+            info_header = make_header_line("[INFO MESSAGE]")
+            warning_header = make_header_line("[New Check Warning]")
+
+            msg = (
+                f"\n\n{info_header}\n\n"
+                f"{'=' * len(info_header)}\n\n"
+                f"{warning_header}\n\n"
+                f"{msg}\n"
+                "Please fix this warning related to the new check "
+                "before the release of the next version of Docs-As-Code.\n"
             )
             self.info(msg, location)
         else:


### PR DESCRIPTION
In this PR, we improved the new checks, warnings logs, and separated them from normal checks(example in the attached image)

<img width="1139" height="172" alt="exemple-new-checks" src="https://github.com/user-attachments/assets/a7de84b2-1bf2-4ef6-8f12-457b41792866" />


close: https://github.com/eclipse-score/docs-as-code/issues/155