### PR TITLE
Add documentation check command and time tracking

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -86,6 +86,19 @@ def docs(source_dir = "docs", data = [], deps = []):
     )
 
     py_binary(
+        name = "docs_check",
+        tags = ["cli_help=Verify documentation [run]"],
+        srcs = ["@score_docs_as_code//src:incremental.py"],
+        data = data,
+        deps = deps,
+        env = {
+            "SOURCE_DIRECTORY": source_dir,
+            "DATA": str(data),
+            "ACTION": "check",
+        },
+    )
+
+    py_binary(
         name = "live_preview",
         tags = ["cli_help=Live preview documentation in the browser [run]"],
         srcs = ["@score_docs_as_code//src:incremental.py"],

--- a/src/incremental.py
+++ b/src/incremental.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 
 import debugpy
@@ -102,4 +103,24 @@ if __name__ == "__main__":
             ]
         )
     else:
-        sys.exit(sphinx_main(base_arguments))
+        if action == "incremental":
+            builder = "html"
+        elif action == "check":
+            builder = "needs"
+        else:
+            raise ValueError(f"Unknown action: {action}")
+
+        base_arguments.extend(
+            [
+                "-b",
+                builder,
+            ]
+        )
+
+        start_time = time.perf_counter()
+        exit_code = sphinx_main(base_arguments)
+        end_time = time.perf_counter()
+        duration = end_time - start_time
+        print(f"docs ({action}) finished in {duration:.1f} seconds")
+
+        sys.exit(exit_code)


### PR DESCRIPTION
Introduce a command to verify documentation (undocumented = experimental) and implement time tracking for the documentation build process.