### PR TITLE
Add Pull request template for docs-as-code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+Thank you for your contribution!
+Please fill out this template to help us review your PR effectively.
+-->
+
+## 📌 Description
+- What does this PR change?
+- Why is it needed?
+- Which task it's related to?
+
+## ✅ Checklist
+Before requesting a review, please confirm that you have:
+
+- [ ] Added/updated documentation for new or changed features
+- [ ] Added/updated tests to cover the changes
+- [ ] Verified that existing tests pass locally
+- [ ] Followed project coding standards and guidelines
+
+## 🧪 Testing
+- How did you test your changes?
+- Any special test setup required?
+
+## 📖 Documentation
+- Does this PR update docs?
+- If not, explain why documentation is not needed.
+
+---
+
+⚠️ **Note:** Pull requests with missing tests or documentation will not be merged.


### PR DESCRIPTION
In this PR, we added a pull request template containing the steps that need to be done so the PR will be accepted by the reviewers (content can be changed), which will be included automatically in the description of new PRs.

close: https://github.com/eclipse-score/docs-as-code/issues/117