### PR TITLE
Add Decision Record support

### DIFF
--- a/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
+++ b/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
@@ -5,7 +5,7 @@ owner: Infrastructure Community
 ---
 
 :::{dec_rec} Decision Record 001: Test results in Docs-As-Code Workflows
-:id: dec_rec__docs_as_code__001_test_results_in_docs_as_code_workflows
+:id: dec_rec__docs_as_code__001_results_in_wfs
 :status: accepted
 :context: see below...
 :decision: see below...

--- a/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
+++ b/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
@@ -4,6 +4,14 @@ status: "Draft"
 owner: Infrastructure Community
 ---
 
+:::{dec_rec} Decision Record 001: Test results in Docs-As-Code Workflows
+:id: dec_rec__docs_as_code__001_test_results_in_docs_as_code_workflows
+:status: accepted
+:context: see below...
+:decision: see below...
+:consequences: implementation effort
+:::
+
 # Decision Record 001: Test results in Docs-As-Code Workflows
 
 ## Goals

--- a/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
+++ b/docs/internals/decisions_and_concepts/001-test-results-in-workflow.md
@@ -1,14 +1,8 @@
----
-id: Docs-As-Code-DR-001
-status: "Draft"
-owner: Infrastructure Community
----
-
 :::{dec_rec} Decision Record 001: Test results in Docs-As-Code Workflows
-:id: dec_rec__docs_as_code__001_results_in_wfs
+:id: dec_rec__dac__001_test_results_in_workflows
 :status: accepted
-:context: see below...
-:decision: see below...
+:context: Need to embed test results into docs, but tests are slow.
+:decision: Run quick docs checks and tests in parallel, then full docs generation sequentially.
 :consequences: implementation effort
 :::
 

--- a/docs/internals/decisions_and_concepts/index.rst
+++ b/docs/internals/decisions_and_concepts/index.rst
@@ -6,3 +6,8 @@ Decisions And Concepts
    :glob:
 
    *
+
+.. needtable::
+   :style: table
+   :types: dec_rec
+   :columns: id;context;decision;consequences;status

--- a/src/extensions/score_metamodel/checks/id_contains_feature.py
+++ b/src/extensions/score_metamodel/checks/id_contains_feature.py
@@ -35,6 +35,10 @@ def id_contains_feature(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
         # No warning needed here, as this is already checked in the metamodel.
         return
 
+    if parts[0] == "dec_rec":
+        # Decision records are intentionally not located within their components
+        return
+
     # Get the part of the string after the first two underscores: the path
     feature = parts[1]
     if feature == "example_feature":

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -848,6 +848,7 @@ needs_types:
       fully_verifies: ^.*$
       partially_verifies: ^.*$
 
+  # https://eclipse-score.github.io/process_description/main/permalink.html?id=gd_temp__change_decision_record
   dec_rec:
     title: Decision Record
     prefix: dec_rec__

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -848,6 +848,19 @@ needs_types:
       fully_verifies: ^.*$
       partially_verifies: ^.*$
 
+  dec_rec:
+    title: Decision Record
+    prefix: dec_rec__
+    mandatory_options:
+      id: ^dec_rec__.*__.*$
+      status: ^(proposed|accepted|deprecated|rejected|superseded)$
+      context: ^.*$
+      decision: ^.*$
+    optional_options:
+      consequences: ^.*$
+    optional_links:
+      affects: ^.*$
+
 # Extra link types, which shall be available and allow need types to be linked to each other.
 # We use a dedicated linked type for each type of a connection, for instance from
 # a specification to a requirement. This makes filtering and visualization of such connections


### PR DESCRIPTION
Introduce a new decision record type and update the relevant functions to handle decision records in the Docs-As-Code workflows. This change enhances the documentation process by formalizing decision-making records.