### PR TITLE
fix: score_sphinx_bundle must load plantuml before sphinx-needs

### DIFF
--- a/src/extensions/score_plantuml.py
+++ b/src/extensions/score_plantuml.py
@@ -68,23 +68,26 @@ def get_runfiles_dir() -> Path:
     return runfiles_dir
 
 
-def find_correct_path(runfiles: str) -> str:
+def find_correct_path(runfiles: Path) -> Path:
     """
     This ensures that the 'plantuml' binary path is found in local 'score_docs_as_code'
     and module use.
     """
-    dirs = [str(x) for x in Path(runfiles).glob("*score_docs_as_code+")]
-    if dirs:
-        # Happens if 'score_docs_as_code' is used as Module
-        p = runfiles + "/score_docs_as_code+/src/plantuml"
+    if (Path(runfiles) / "score_docs_as_code+").exists():
+        # Docs-as-code used as a module with bazel 8
+        module = "score_docs_as_code+"
+    elif (Path(runfiles) / "score_docs_as_code~").exists():
+        # Docs-as-code used as a module with bazel 7
+        module = "score_docs_as_code~"
     else:
-        # Only happens in 'score_docs_as_code' repository
-        p = runfiles + "/../plantuml"
-    return p
+        # Docs-as-code is the current module
+        module = "_main"
+
+    return runfiles / module / "src" / "plantuml"
 
 
 def setup(app: Sphinx):
-    app.config.plantuml = find_correct_path(str(get_runfiles_dir()))
+    app.config.plantuml = str(find_correct_path(get_runfiles_dir()))
     app.config.plantuml_output_format = "svg_obj"
     app.config.plantuml_syntax_error_image = True
     app.config.needs_build_needumls = "_plantuml_sources"

--- a/src/extensions/score_sphinx_bundle/__init__.py
+++ b/src/extensions/score_sphinx_bundle/__init__.py
@@ -14,14 +14,16 @@ from sphinx.application import Sphinx
 
 # Note: order matters!
 # Extensions are loaded in this order.
-# (Although not sure what has to be loaded first)
+# e.g. plantuml MUST be loaded before sphinx-needs
 score_extensions = [
-    "score_metamodel",
-    "sphinx_design",
-    "sphinx_needs",
-    "myst_parser",
     "sphinxcontrib.plantuml",
     "score_plantuml",
+
+    "sphinx_needs",
+
+    "score_metamodel",
+    "sphinx_design",
+    "myst_parser",
     "score_source_code_linker",
     "score_draw_uml_funcs",
     "score_layout",

--- a/src/extensions/score_sphinx_bundle/__init__.py
+++ b/src/extensions/score_sphinx_bundle/__init__.py
@@ -18,9 +18,7 @@ from sphinx.application import Sphinx
 score_extensions = [
     "sphinxcontrib.plantuml",
     "score_plantuml",
-
     "sphinx_needs",
-
     "score_metamodel",
     "sphinx_design",
     "myst_parser",


### PR DESCRIPTION
For binary selection we need to find the plantuml binary manually.

* Instead of globbing, we can look up in the runfiles directory directly
* sphinx 8 has switched `~` to `+`
* plantuml must be loaded before sphinx-needs

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
