### PR TITLE
docs: Check optional links as info

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -138,7 +138,7 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
     # External needs: run a focused, info-only check on optional_links patterns
     # so that optional link issues from imported needs are visible but do not
     # fail builds with -W.
-    _check_external_optional_link_patterns(app, log)
+    # _check_external_optional_link_patterns(app, log)
 
     # Graph-Based checks: These warnings require a graph of all other needs to
     # be checked.
@@ -186,12 +186,15 @@ def _validate_external_need_opt_links(
     log: CheckLogger,
 ) -> None:
     for link_field, pattern in opt_links.items():
-        raw_value = need.get(link_field, None)
+        raw_value: str | list[str] | None = need.get(link_field, None)
         if raw_value in [None, [], ""]:
             continue
 
-        values = raw_value if isinstance(raw_value, list) else [raw_value]
+        values: list[str | Any] = (
+            raw_value if isinstance(raw_value, list) else [raw_value]
+        )
         for value in values:
+            v: str | Any
             if isinstance(value, str):
                 v = _remove_prefix(value, allowed_prefixes)
             else:

--- a/src/extensions/score_metamodel/checks/check_options.py
+++ b/src/extensions/score_metamodel/checks/check_options.py
@@ -70,7 +70,6 @@ def _validate_value_pattern(
             need,
             field,
             f"pattern `{pattern}` is not a valid regex pattern.",
-            is_new_check=as_info,
         )
 
 


### PR DESCRIPTION
Optional links is enabled but the output is displayes as [INFO MESSAGE]. This should be removed after the optional links are fixed and everything threated as warning.

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->

related: https://github.com/eclipse-score/docs-as-code/issues/241
