### PR TITLE
Set generate without sourcecode as a default to sphinx to reduce spac…

### DIFF
--- a/src/extensions/score_sphinx_bundle/__init__.py
+++ b/src/extensions/score_sphinx_bundle/__init__.py
@@ -30,8 +30,6 @@ score_extensions = [
 
 
 def setup(app: Sphinx) -> dict[str, object]:
-    if "score_sphinx_bundle.source_code_linker" in app.config.extensions:
-        app.config.extensions.remove("score_sphinx_bundle.source_code_linker")
     app.config.html_copy_source = False
     app.config.html_show_sourcelink = False
 


### PR DESCRIPTION
…e in the gh_pages by approx. 10%. Add option to generate sourcecode via bazel //:docs -- --sphinx_args -t source

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
There is only 1GB of space available in gh-pages. Therefore, websites created through PR or updates on mein should be as small as possible. For optimization purposes, I have therefore disabled the source code. If necessary, it can be regenerated using an option in the bazel call.

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
