### PR TITLE
Version 1.5.0 adds :html target

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -176,20 +176,23 @@ def docs(source_dir = "docs", data = [], deps = []):
         data = data,
     )
 
-    sphinx_docs(
-        name = "needs_json",
-        srcs = [":docs_sources"],
-        config = ":" + source_dir + "/conf.py",
-        extra_opts = [
-            "-W",
-            "--keep-going",
-            "-T",  # show more details in case of errors
-            "--jobs",
-            "auto",
-            "--define=external_needs_source=" + str(data),
-        ],
-        formats = ["needs"],
-        sphinx = ":sphinx_build",
-        tools = data,
-        visibility = ["//visibility:public"],
-    )
+    # Create sphinx_docs targets for different output formats
+    formats = {"needs_json": "needs", "html": "html"}
+    for target_name, format_type in formats.items():
+        sphinx_docs(
+            name = target_name,
+            srcs = [":docs_sources"],
+            config = ":" + source_dir + "/conf.py",
+            extra_opts = [
+                "-W",
+                "--keep-going",
+                "-T",  # show more details in case of errors
+                "--jobs",
+                "auto",
+                "--define=external_needs_source=" + str(data),
+            ],
+            formats = [format_type],
+            sphinx = ":sphinx_build",
+            tools = data,
+            visibility = ["//visibility:public"],
+        )

--- a/docs/how-to/commands.md
+++ b/docs/how-to/commands.md
@@ -8,6 +8,7 @@
 | `bazel run //:live_preview`                    | Creates a live_preview of the documentation viewable in a local server                            |
 | `bazel run //:live_preview_combo_experimental` | Creates a live_preview of the full documentation with all dependencies viewable in a local server |
 | `bazel run //:ide_support`                     | Sets up a Python venv for esbonio (Remember to restart VS Code!)                                  |
+| `bazel run //:html.serve`                      | Serves the generated HTML documentation on a local web server                                     |
 
 ## Internal targets (do not use directly)
 
@@ -15,3 +16,4 @@
 | ----------------------------- | ------------------------------------------- |
 | `bazel build //:needs_json`   | Creates a 'needs.json' file                 |
 | `bazel build //:docs_sources` | Provides all the documentation source files |
+| `bazel build //:html`         | Builds the documentation                    |


### PR DESCRIPTION
## 📌 Description

Offers an additional Bazel target for docs-as-code users to build inside the Bazel sandbox.

As a side effect, another commit on the main branch becomes part of this version increment. If we merge this first, then we can remove the git override in [this other PR](https://github.com/eclipse-score/reference_integration/pull/14/files?diff=unified&w=0#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcR31).

## 🚨 Impact Analysis

Additional feature fully backwards compatible.

- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines
