### PR TITLE
Add support for external needs in PlantUML drawing

### DIFF
--- a/src/extensions/score_draw_uml_funcs/helpers.py
+++ b/src/extensions/score_draw_uml_funcs/helpers.py
@@ -111,7 +111,10 @@ def get_alias(need: dict[str, str]) -> str:
 
 def get_need_link(need: dict[str, str]) -> str:
     """Generate the link to the need element from the PlantUML Diagram"""
-    link = ".." + "/" + need["docname"] + ".html#" + need["id_parent"]
+    if need["is_external"]:
+        link = need["external_url"]
+    else:
+        link = f"../{need['docname']}.html#{need['id_parent']}"
 
     # Reminder: Link is displayed via triple braces inside a interface
     if "int_op" in need["type"]:


### PR DESCRIPTION
## 📌 Description

When attempting to draw UML diagram with `draw_component()` where external needs are referenced, the documentation build fails with a Python exception coming from the `get_need_link` function.

According to https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.data.NeedsSourceInfoType,  external needs do not define the `docname` field, which is used in the HTML link construction. This PR extends the `get_need_link` with the support for external needs.


## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features -> minor change, no update needed
- [ ] Added/updated tests to cover the changes -> there is no test infrastructure for component drawing.
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->