### PR TITLE
Change docs_sources to spinx_docs_library

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -79,7 +79,7 @@ def docs(source_dir = "docs", data = [], deps = []):
         deps = deps,
     )
 
-    pkg_files(
+    sphinx_docs_library(
         name = "docs_sources",
         srcs = native.glob([
             source_dir + "/**/*.png",
@@ -97,6 +97,7 @@ def docs(source_dir = "docs", data = [], deps = []):
             "more_docs/**/*.rst",
         ], allow_empty = True),
         strip_prefix = strip_prefix.from_pkg(),  # avoid flattening of folders
+        prefix = "docs/modules/x/",
         visibility = ["//visibility:public"],
     )
 
@@ -178,7 +179,7 @@ def docs(source_dir = "docs", data = [], deps = []):
 
     sphinx_docs(
         name = "needs_json",
-        srcs = [":docs_sources"],
+        srcs = [],  # empty as we pull in all docs via deps
         config = ":" + source_dir + "/conf.py",
         extra_opts = [
             "-W",
@@ -191,5 +192,6 @@ def docs(source_dir = "docs", data = [], deps = []):
         formats = ["needs"],
         sphinx = ":sphinx_build",
         tools = data,
+        deps = [":docs_sources"],
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
## 📌 Description
This PR introduces the 2 features: 
1. It moves the sphinx build into bazels execution phase
2. It introduces a sphinx_docs_library target to support the integration of sphinx_docs from different module to s single documentation

## 🚨 Impact Analysis
- [X] This change does not violate any tool requirements and is covered by existing tool requirements
- [X] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [X] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
