### PR TITLE
Fix compatibility with rules_python >= 1.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "rules_pkg", version = "1.1.0")
 # Python version
 #
 ###############################################################################
-bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_python", version = "1.5.0")
 
 PYTHON_VERSION = "3.12"
 

--- a/src/extensions/BUILD
+++ b/src/extensions/BUILD
@@ -20,4 +20,8 @@ py_library(
     srcs = ["@score_docs_as_code//src/extensions:score_plantuml.py"],
     imports = ["."],
     visibility = ["//visibility:public"],
+    deps = [
+        "@rules_python//python/runfiles",
+        "@score_docs_as_code//src:plantuml_for_python",
+    ],
 )

--- a/src/extensions/score_plantuml.py
+++ b/src/extensions/score_plantuml.py
@@ -24,10 +24,10 @@ Sphinx configuration.
 In addition it sets common PlantUML options, like output to svg_obj.
 """
 
-import os
 import sys
 from pathlib import Path
 
+from python.runfiles import Runfiles
 from sphinx.application import Sphinx
 from sphinx.util import logging
 
@@ -35,13 +35,13 @@ logger = logging.getLogger(__name__)
 
 
 def get_runfiles_dir() -> Path:
-    if r := os.getenv("RUNFILES_DIR"):
+    if (r := Runfiles.Create()) and (rd := r.EnvVars().get("RUNFILES_DIR")):
         # Runfiles are only available when running in Bazel.
         # bazel build and bazel run are both supported.
         # i.e. `bazel build //:docs` and `bazel run //:docs`.
         logger.debug("Using runfiles to determine plantuml path.")
 
-        runfiles_dir = Path(r)
+        runfiles_dir = Path(rd)
 
     else:
         # The only way to land here is when running from within the virtual


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->
`rules_python` 1.5.0 broke the way the package discovers the plantuml tool resulting in errors
when building the `:needs_json` target.

This PR fixes #295

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [x] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
