### PR TITLE
Fix 'edit on github' button

### DIFF
--- a/src/incremental.py
+++ b/src/incremental.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         base_arguments.append(f"-A=github_user={args.github_user}")
         base_arguments.append(f"-A=github_repo={args.github_repo}")
         base_arguments.append("-A=github_version=main")
-        base_arguments.append(f"-A=doc_path='{get_env('SOURCE_DIRECTORY')}'")
+        base_arguments.append(f"-A=doc_path={get_env('SOURCE_DIRECTORY')}")
 
     action = get_env("ACTION")
     if action == "live_preview":


### PR DESCRIPTION
## 📌 Description
Removes quotes around the name of the document source (e.g 'docs' => docs) to fix the `edit on github` link

Fixes: #348 

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
