### PR TITLE
Fixing consumer test pipe

### DIFF
--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -39,8 +39,13 @@ jobs:
         run: |
           mkdir -p reports
 
+      # The pipefail ensures that non 0 exit codes inside the pytest execution get carried into the pipe 
+      # & make the tests red in the end. Without this we only would check the exit code of the 'tee' command.
       - name: Run Consumer tests
-        run: "set -o pipefail \n.venv_docs/bin/python -m pytest -s -v src/tests/ --repo=\"$CONSUMER\" --junitxml=\"reports/${{ matrix.consumer }}.xml\" | tee \"reports/${{ matrix.consumer }}.log\"\n#magic___^_^___line\n"
+
+        run: |
+          set -o pipefail
+          .venv_docs/bin/python -m pytest -s -v src/tests/ --repo="$CONSUMER" --junitxml="reports/${{ matrix.consumer }}.xml" | tee "reports/${{ matrix.consumer }}.log"
         env:
           FORCE_COLOR: "1"
           TERM: xterm-256color


### PR DESCRIPTION
The pipe into 'tee' has made it so only the exit code of the 'tee' action was recorded / interpreted by github. This meant that any fail inside the consumer test was ignored and it only failed if the 'tee' action would fail.

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
