### PR TITLE
Disable ubproject.toml warning on diff

### DIFF
--- a/src/extensions/score_sync_toml/__init__.py
+++ b/src/extensions/score_sync_toml/__init__.py
@@ -34,7 +34,7 @@ def setup(app: Sphinx) -> dict[str, str | bool]:
     app.config.needscfg_exclude_defaults = True
     """Exclude default values from the generated configuration."""
 
-    # This is disabled for right now as it causes a lot of issues 
+    # This is disabled for right now as it causes a lot of issues
     # While we are not using the generated file anywhere
     app.config.needscfg_warn_on_diff = False
     """Running Sphinx with -W will fail the CI for uncommitted TOML changes."""


### PR DESCRIPTION
## 📌 Description
Pr changes default behaviour of needs_config_writer to not warn on diff anymore.

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
