### PR TITLE
Convert markdown table to reStructuredText format

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -997,12 +997,18 @@ Testing
   Docs-As-Code shall enforce that needs of type :need:`tool_req__docs_saf_types` have a
   `violates` links to at least one dynamic / static diagram according to the table.
 
-  | Source | Target |
-  | -- | -- |
-  | feat_saf_dfa | feat_arc_sta |
-  | comp_saf_dfa | comp_arc_sta |
-  | feat_saf_fmea | feat_arc_dyn |
-  | comp_saf_fmea | comp_arc_dyn |
+  
+  .. table::
+     :widths: auto
+   
+     =============  ===================
+     Link Source    Allowed Link Target 
+     =============  ===================
+     feat_saf_dfa   feat_arc_sta 
+     comp_saf_dfa   comp_arc_sta 
+     feat_saf_fmea  feat_arc_dyn 
+     comp_saf_fmea  comp_arc_dyn
+     =============  ===================
 
 
 


### PR DESCRIPTION
Convert markdown table to reStructuredText format

## 📌 Description
Replaced the markdown table with a reStructuredText table format in the description of reqid: Safety Analysis Linkage Violates 

## 🚨 Impact Analysis
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines