### PR TITLE
Accept module root folder as docs source_dir

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -137,15 +137,9 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = []):
     if call_path != "":
         fail("docs() must be called from the root package. Current package: " + call_path)
 
-    # Strip trailing slashes from source_dir (e.g. "docs/" -> "docs")
-    for _ in range(len(source_dir)):
-        if source_dir.endswith("/"):
-            source_dir = source_dir[:-1]
-        else:
-            break
 
-    # Normalize "." and "" to "" (workspace root)
-    if source_dir == "." or source_dir == "":
+    # Normalize "." and "./" to "" (workspace root)
+    if source_dir == "." or source_dir == "./":
         source_dir = ""
 
     # Prefix for glob patterns and label paths: "dir/" or "" at workspace root.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->
Accept module root folder as docs source_dir. This allows users to place the documentation entry 
inside the module root folder. This overcomes the restriction that Sphinx does not allow upwards 
referencing with "../", making it impossible to reference files above the docs folder. [See](https://github.com/eclipse-score/docs-as-code/issues/429) .

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [ ] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
