### PR TITLE
Converting pytest to pyrproject.toml

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ load("@score_tooling//:defs.bzl", "cli_helper", "copyright_checker")
 load("//:docs.bzl", "docs")
 
 package(default_visibility = ["//visibility:public"])
+exports_files(["pyproject.toml"])
 
 copyright_checker(
     name = "copyright",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,47 @@ extend-exclude = [
     "bazel-*",
     ".venv*/**",
 ]
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "Debug"
+log_cli_format = "[%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
+log_format = "[%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
+
+log_file_level = "Debug"
+log_file_format = "[%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s"
+log_file_date_format = "%Y-%m-%d %H:%M:%S"
+
+markers = [
+    "metadata",
+    "test_properties(dict): Add custom properties to test XML output",
+]
+
+norecursedirs = [
+    ".*",        # hidden folders like .git, .venv, .cache, etc.
+    "_build*",   # common docs-as-code directory
+    "bazel-*",   # Bazel output folders
+]
+
+junit_duration_report = "call"
+junit_family = "xunit1"
+
+filterwarnings = [
+    "ignore::pytest.PytestExperimentalApiWarning",
+    # Silence third-party deprecations from sphinx_needs targeting Python 3.14 removals.
+    # We'll drop these ignores once sphinx_needs releases a fix.
+    "ignore:.*deprecated.*Python 3\\.14.*:DeprecationWarning:sphinx_needs\\..*",
+    # Docutils is deprecating OptionParser in favor of argparse (0.21+).
+    # This one originates inside sphinx_needs.layout.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    "ignore:^The frontend\\.OptionParser class will be replaced by a subclass of argparse\\.ArgumentParser in Docutils 0\\.21 or later\\.:DeprecationWarning:sphinx_needs\\.layout",
+    # This one bubbles up from stdlib optparse but is *explicitly* a Docutils message.
+    # We match the full message to avoid silencing unrelated optparse warnings.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    "ignore:^The frontend\\.Option class will be removed in Docutils 0\\.21 or later\\.:DeprecationWarning:optparse",
+]
+pythonpath = [
+    "src/extensions/",
+]

--- a/scripts_bazel/tests/BUILD
+++ b/scripts_bazel/tests/BUILD
@@ -21,6 +21,7 @@ score_py_pytest(
         "//scripts_bazel:generate_sourcelinks",
         "//src/extensions/score_source_code_linker",
     ] + all_requirements,
+    pytest_config = "//:pyproject.toml",
 )
 
 score_py_pytest(
@@ -29,4 +30,5 @@ score_py_pytest(
     deps = [
         "//scripts_bazel:merge_sourcelinks",
     ] + all_requirements,
+    pytest_config = "//:pyproject.toml",
 )

--- a/src/extensions/score_any_folder/BUILD
+++ b/src/extensions/score_any_folder/BUILD
@@ -47,4 +47,5 @@ score_py_pytest(
     size = "small",
     srcs = glob(["tests/*.py"]),
     deps = [":score_any_folder"],
+    pytest_config = "//:pyproject.toml",
 )

--- a/src/extensions/score_header_service/BUILD
+++ b/src/extensions/score_header_service/BUILD
@@ -36,4 +36,5 @@ score_py_pytest(
     srcs = glob(["test/**/*.py"]),
     # All requirements already in the library so no need to have it double
     deps = [":score_header_service"],
+    pytest_config = "//:pyproject.toml",
 )

--- a/src/extensions/score_metamodel/BUILD
+++ b/src/extensions/score_metamodel/BUILD
@@ -66,4 +66,5 @@ score_py_pytest(
         ],
     ) + ["tests/rst/conf.py"],
     deps = [":score_metamodel"],
+    pytest_config = "//:pyproject.toml",
 )

--- a/src/extensions/score_source_code_linker/BUILD
+++ b/src/extensions/score_source_code_linker/BUILD
@@ -75,4 +75,5 @@ score_py_pytest(
         ":score_source_code_linker",
         "//src/extensions/score_metamodel",
     ],
+    pytest_config = "//:pyproject.toml",
 )

--- a/src/helper_lib/BUILD
+++ b/src/helper_lib/BUILD
@@ -38,4 +38,5 @@ score_py_pytest(
     deps = [
         ":helper_lib",
     ] + all_requirements,
+    pytest_config = "//:pyproject.toml",
 )


### PR DESCRIPTION
## 📌 Description
Move pytest init configuration to pyproject.toml to enable testing from ref-integration

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
