### PR TITLE
Disable persistent workers in sphinx_docs

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -294,6 +294,9 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         sphinx = ":sphinx_build",
         tools = data,
         visibility = ["//visibility:public"],
+        # Persistent workers cause stale symlinks after dependency version
+        # changes, corrupting the Bazel cache.
+        allow_persistent_workers = False,
     )
 
     sphinx_module(


### PR DESCRIPTION
Persistent workers cause Bazel cache corruption when external dependency versions change (stale symlinks remain visible to Sphinx). There is a performance cost to disabling this feature.

Fixes #452 

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [x] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
