### PR TITLE
Allow satisfies link from tool_req to feat_req and comp_req.

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -495,14 +495,14 @@ Versioning
   .. table::
      :widths: auto
 
-     ================================ ====================================================================
+     ================================ ========================================================
      Source Type                      Allowed Link Target
-     ================================ ====================================================================
+     ================================ ========================================================
      Feature Requirements             Stakeholder Requirements
      Component Requirements           Feature Requirements
      Process Requirements             Workflows
-     Tooling Requirements             Process Requirements, Stakeholder Requirements, Feature Requirements
-     ================================ ====================================================================
+     Tooling Requirements             Process-, Stakeholder-, Feature-, Component Requirements
+     ================================ ========================================================
 
   .. note::
       Certain tool requirements do not have a matching process requirement.

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -344,7 +344,7 @@ needs_types:
     optional_links:
       # req-Id: tool_req__docs_req_link_satisfies_allowed
       # TODO: make it mandatory
-      satisfies: gd_req, stkh_req, feat_req
+      satisfies: gd_req, stkh_req, feat_req, comp_req
     optional_options:
       codelink: ^.*$
       tags: ^.*$


### PR DESCRIPTION
## 📌 Description
Allow satisfies link from tool requirements (tool_req) to feature-, component requirements.
Discussed in [SW Dev Process Community Meeting 31.03](https://github.com/orgs/eclipse-score/discussions/2234?sort=new#discussioncomment-16343589)
Process update: [PR630](https://github.com/eclipse-score/process_description/pull/630)

## 🚨 Impact Analysis
- [X] This change does not violate any tool requirements and is covered by existing tool requirements
- [X] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
- [X] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [X] Followed project coding standards and guidelines
