### PR TITLE
feat: score_pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run test targets
         run: |
           bazel run --lockfile_mode=error //:ide_support
-          bazel test --lockfile_mode=error //src/...
+          bazel test --lockfile_mode=error //src/... //score_pytest/...
 
       - name: Prepare bundled consumer report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ styles/
 .venv*
 __pycache__/
 /.coverage
+
+# bug: This file is created in repo root on test discovery.
+/consumer_test.log

--- a/score_pytest.bzl
+++ b/score_pytest.bzl
@@ -12,20 +12,29 @@
 # *******************************************************************************
 """Bazel interface for running pytest"""
 
-load("@pip_tooling//:requirements.bzl", "all_requirements")
+load("@docs_as_code_hub_env//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
-def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugins = [], pytest_config = None, **kwargs):
-    pytest_bootstrap = Label("@score_tooling//python_basics/score_pytest:main.py")
+def score_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugins = [], pytest_config = None, **kwargs):
+    pytest_bootstrap = Label("@score_docs_as_code//score_pytest:main.py")
 
     if not pytest_config:
-        pytest_config = Label("@score_tooling//python_basics/score_pytest:pytest.ini")
-        #fail("$(location %s)" % pytest_config)
+        pytest_config = Label("@score_docs_as_code//score_pytest:pytest.ini")
 
     if not srcs:
         fail("No source files provided for %s! (Is your glob empty?)" % name)
 
     plugins = ["-p attribute_plugin"] + ["-p %s" % plugin for plugin in plugins]
+
+    docs_pytest = requirement("pytest")
+    pytest_in_deps = False
+    for dep in deps:
+        if "//pytest:pkg" in str(dep):
+            if str(dep) != str(docs_pytest):
+                fail("Please do not provide your own pytest version. We want to use the same pytest version everywhere.")
+            pytest_in_deps = True
+    if not pytest_in_deps:
+        deps = deps + [docs_pytest]
 
     py_test(
         name = name,
@@ -46,7 +55,7 @@ def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugi
                args +
                plugins +
                ["$(location %s)" % x for x in srcs],
-        deps = ["@score_tooling//python_basics/score_pytest:attribute_plugin"] + all_requirements + deps,
+        deps = deps + ["@score_docs_as_code//score_pytest:attribute_plugin"],
         data = [
             pytest_config,
         ] + data,

--- a/score_pytest/BUILD
+++ b/score_pytest/BUILD
@@ -1,0 +1,38 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@score_tooling//python_basics/score_pytest:py_pytest.bzl", "score_py_pytest")
+
+exports_files([
+    "pytest.ini",
+    "main.py",
+    "py_pytest.bzl",
+])
+
+score_py_pytest(
+    name = "test_rules_are_working_correctly",
+    srcs = glob(
+        [
+            "tests/*.py",
+        ],
+        allow_empty = True,
+    ),
+)
+
+py_library(
+    name = "attribute_plugin",
+    srcs = ["attribute_plugin.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/score_pytest/BUILD
+++ b/score_pytest/BUILD
@@ -12,22 +12,16 @@
 # *******************************************************************************
 
 load("@aspect_rules_py//py:defs.bzl", "py_library")
-load("@score_tooling//python_basics/score_pytest:py_pytest.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
 exports_files([
     "pytest.ini",
     "main.py",
-    "py_pytest.bzl",
 ])
 
-score_py_pytest(
+score_pytest(
     name = "test_rules_are_working_correctly",
-    srcs = glob(
-        [
-            "tests/*.py",
-        ],
-        allow_empty = True,
-    ),
+    srcs = glob(["tests/*.py"]),
 )
 
 py_library(

--- a/score_pytest/README.md
+++ b/score_pytest/README.md
@@ -16,7 +16,7 @@ This module provides support for running [pytest](https://docs.pytest.org/en/lat
 - **Requirements Traceability**: Link tests to requirement IDs
 - **Automatic File/Line Attribution**: Annotates tests with file path and line number
 - **JUnit XML Integration**: Exports metadata as `<properties>` in test reports
-- **Bazel Integration**: Run tests with `score_py_pytest` Bazel rule
+- **Bazel Integration**: Run tests with `score_pytest` Bazel rule
 
 ---
 
@@ -24,20 +24,29 @@ This module provides support for running [pytest](https://docs.pytest.org/en/lat
 
 ### In `MODULE.bazel`
 
-```starlark
-bazel_dep(name = "score_python_basics", version = "0.1.0")
-```
-
-> The `score_pytest` module will determine the appropriate `pytest` version. It is not possible to override this.
+Add a dependency to `score_docs_as_code` to use the `score_pytest` module.
+The module will determine the appropriate `pytest` version. It is not possible to override this.
 
 ---
 
 ### In `BUILD`
 
 ```starlark
-load("@score_python_basics//score_pytest:py_pytest.bzl", "score_py_pytest")
+load("@score_docs_as_code//:score_pytest.bzl", "score_pytest")
 
-score_py_pytest(
+# simple case:
+score_pytest(
+    name = "test_my_first_check",
+    srcs = ["test_my_first_check.py"],
+
+    # Optional custom pyproject.toml or pytest.ini
+    # Recommended if you have one.
+    # This will align CLI, IDE and bazel test behavior.
+    pytest_config = "//:pyproject.toml",
+)
+
+# all options:
+score_pytest(
     name = "test_my_first_check",
     srcs = ["test_my_first_check.py"],
     plugins = [
@@ -49,7 +58,7 @@ score_py_pytest(
     env = {
         "LD_LIBRARY_PATH": "/path/to/dynamic/lib",  # Optional environment
     },
-    pytest_ini = "//my_pytest:my_pytest_ini",  # Optional custom pytest.ini
+    pytest_config = "//:pytest_ini",  # Optional custom pytest.ini
     tags = ["integration"]  # Optional tags for test grouping
 )
 ```
@@ -80,8 +89,6 @@ def test_user_login():
 - `test_type`: Type of test being executed
 - `derivation_technique`: Method used to derive the test
 - **Either** `partially_verifies` or `fully_verifies`: List of requirement IDs
-
-> ?? All decorated tests **must include a docstring**.
 
 ---
 
@@ -162,27 +169,3 @@ When using `--junit-xml=report.xml`, the plugin augments each test case with:
   </testsuite>
 </testsuites>
 ```
-
----
-
-## Development of `score_pytest`
-
-### Updating `pytest` and dependencies
-
-Update the dependencies listed in `requirements.txt` and lock them with:
-
-```bash
-bazel run //:requirements.update -- --upgrade
-```
-
----
-
-### Running Tests
-
-To run the internal tests for this module:
-
-```bash
-bazel test //...
-```
-
----

--- a/score_pytest/README.md
+++ b/score_pytest/README.md
@@ -1,0 +1,188 @@
+<!--
+Copyright (c) 2026 Contributors to the Eclipse Foundation
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Score pytest wrapper & plugin
+
+This module provides support for running [pytest](https://docs.pytest.org/en/latest/contents.html)-based tests with Bazel, and includes a **pytest plugin** that adds structured metadata to JUnit XML reports, improving traceability, test classification, and documentation.
+
+---
+
+## Features
+
+- **Test Classification**: Categorize tests by type and derivation technique
+- **Requirements Traceability**: Link tests to requirement IDs
+- **Automatic File/Line Attribution**: Annotates tests with file path and line number
+- **JUnit XML Integration**: Exports metadata as `<properties>` in test reports
+- **Bazel Integration**: Run tests with `score_py_pytest` Bazel rule
+
+---
+
+## Usage
+
+### In `MODULE.bazel`
+
+```starlark
+bazel_dep(name = "score_python_basics", version = "0.1.0")
+```
+
+> The `score_pytest` module will determine the appropriate `pytest` version. It is not possible to override this.
+
+---
+
+### In `BUILD`
+
+```starlark
+load("@score_python_basics//score_pytest:py_pytest.bzl", "score_py_pytest")
+
+score_py_pytest(
+    name = "test_my_first_check",
+    srcs = ["test_my_first_check.py"],
+    plugins = [
+        # Optionally specify additional pytest plugins
+    ],
+    args = [
+        "--basetemp=/tmp/pytest",  # Optional args
+    ],
+    env = {
+        "LD_LIBRARY_PATH": "/path/to/dynamic/lib",  # Optional environment
+    },
+    pytest_ini = "//my_pytest:my_pytest_ini",  # Optional custom pytest.ini
+    tags = ["integration"]  # Optional tags for test grouping
+)
+```
+
+---
+
+## Using the Test Properties Plugin
+
+You can use the provided `add_test_properties` decorator to enhance your tests with metadata:
+
+### Example
+
+```python
+from your_module import add_test_properties
+
+@add_test_properties(
+    partially_verifies=["REQ-001", "REQ-002"],
+    test_type="interface-test",
+    derivation_technique="boundary-values"
+)
+def test_user_login():
+    """Test user login with valid credentials."""
+    ...
+```
+
+### Required Parameters
+
+- `test_type`: Type of test being executed
+- `derivation_technique`: Method used to derive the test
+- **Either** `partially_verifies` or `fully_verifies`: List of requirement IDs
+
+> ?? All decorated tests **must include a docstring**.
+
+---
+
+### Accepted Values
+
+#### Test Types
+
+- `fault-injection`
+- `interface-test`
+- `requirements-based`
+- `resource-usage`
+
+#### Derivation Techniques
+
+- `requirements-analysis`
+- `design-analysis`
+- `boundary-values`
+- `equivalence-classes`
+- `fuzz-testing`
+- `error-guessing`
+- `explorative-testing`
+
+---
+
+### More Examples
+
+```python
+@add_test_properties(
+    fully_verifies=["REQ-AUTH-001"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis"
+)
+def test_authentication_flow():
+    """Complete authentication flow test."""
+    ...
+
+@add_test_properties(
+    partially_verifies=["REQ-UI-001", "REQ-UI-002"],
+    test_type="interface-test",
+    derivation_technique="boundary-values"
+)
+def test_form_validation():
+    """Test form input validation boundaries."""
+    ...
+```
+
+---
+
+## Output in JUnit XML
+
+When using `--junit-xml=report.xml`, the plugin augments each test case with:
+
+- **Properties**:
+  - `PartiallyVerifies` or `FullyVerifies`
+  - `TestType`
+  - `DerivationTechnique`
+- **File** and **Line**: Relative source path and line number of the test function
+
+### Example Output
+
+```xml
+<testsuites>
+  <testsuite name="TestInterfaceValidation" tests="2" failures="0" errors="0" time="0.123">
+    <testcase name="test_api_response_format" file="src/testfile_1.py" line="10" time="0.056">
+      <properties>
+        <property name="PartiallyVerifies" value="TREQ_ID_2, TREQ_ID_3"/>
+        <property name="TestType" value="interface-test"/>
+        <property name="DerivationTechnique" value="design-analysis"/>
+      </properties>
+    </testcase>
+    <testcase name="test_error_handling" file="src/testfile_1.py" line="38" time="0.067">
+      <properties>
+        <property name="PartiallyVerifies" value="TREQ_ID_2, TREQ_ID_3"/>
+        <property name="TestType" value="interface-test"/>
+        <property name="DerivationTechnique" value="design-analysis"/>
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+---
+
+## Development of `score_pytest`
+
+### Updating `pytest` and dependencies
+
+Update the dependencies listed in `requirements.txt` and lock them with:
+
+```bash
+bazel run //:requirements.update -- --upgrade
+```
+
+---
+
+### Running Tests
+
+To run the internal tests for this module:
+
+```bash
+bazel test //...
+```
+
+---

--- a/score_pytest/attribute_plugin.py
+++ b/score_pytest/attribute_plugin.py
@@ -75,7 +75,7 @@ def add_test_properties(
         # Ensure a 'description' is there inside the Docstring
         if not func.__doc__ or not func.__doc__.strip():
             raise ValueError(
-                f"{func.__name__} does not have a description."
+                f"{func.__name__} does not have a description. "
                 + "Descriptions (in docstrings) are mandatory."
             )
         # NOTE: This might come back to bite us in some weird edgecase, though I have not thought of one so far
@@ -86,9 +86,14 @@ def add_test_properties(
     return decorator
 
 
-def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) -> None:
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
     """Attach file and line info to the report for use in junitxml output."""
-    if call.when != "call":
+
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when != "call":
         return
     # Since our decorator 'add_test_properties' will create a 'test_properties' marker
     # This function then searches for the nearest dictionary attached to an item with
@@ -100,7 +105,16 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) ->
     # Note: This does NOT add 'line' and 'file' to the testcase.
 
     marker = item.get_closest_marker("test_properties")
-    if marker and isinstance(marker.args[0], dict):
+    if not marker:
+        return
+
+    if not marker.args:
+        raise ValueError(
+            f"Marker 'test_properties' on {item.name} does not have any arguments. "
+            + "Please ensure that the 'add_test_properties' decorator is used correctly."
+        )
+
+    if isinstance(marker.args[0], dict):
         for k, v in marker.args[0].items():
             item.user_properties.append((k, str(v)))
 
@@ -116,5 +130,5 @@ def add_file_and_line_attr(
     # turning `../../../_main/<file_path>` into => <filepath>
     clean_file_path = raw_file_path.split("_main/")[-1]
     record_xml_attribute("file", str(clean_file_path))
-    # Adding +1 to the line so we point to the decorator instead of above it
+    # Convert pytest's 0-based source line number to 1-based numbering for XML output.
     record_xml_attribute("line", str(line_number + 1))

--- a/score_pytest/attribute_plugin.py
+++ b/score_pytest/attribute_plugin.py
@@ -1,0 +1,120 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal
+
+import pytest
+
+# Type aliases for better readability
+TestFunction = Callable[..., Any]
+Decorator = Callable[[TestFunction], TestFunction]
+
+
+def add_test_properties(
+    *,
+    partially_verifies: list[str] | None = None,
+    fully_verifies: list[str] | None = None,
+    test_type: Literal[
+        "fault-injection", "interface-test", "requirements-based", "resource-usage"
+    ],
+    derivation_technique: Literal[
+        "requirements-analysis",
+        "design-analysis",
+        "boundary-values",
+        "equivalence-classes",
+        "fuzz-testing",
+        "error-guessing",
+        "explorative-testing",
+    ],
+) -> Decorator:
+    """
+    Decorator to add user properties, file and lineNr to testcases in the XML output
+    """
+    # Early error handling
+    if partially_verifies is None and fully_verifies is None:
+        raise ValueError(
+            "Either 'partially_verifies' or 'fully_verifies' must be provided."
+        )
+
+    #          ╭──────────────────────────────────────╮
+    #          │  HINT. This is currently commented   │
+    #          │ out to not restrict usage a lot but  │
+    #          │   will be commented back in in the   │
+    #          │                future                │
+    #          ╰──────────────────────────────────────╯
+
+    # if not test_type:
+    #     raise ValueError("'test_type' is required and cannot be empty.")
+    #
+    # if not derivation_technique:
+    #     raise ValueError("'derivation_technique' is required and cannot be empty.")
+    #
+
+    def decorator(func: TestFunction) -> TestFunction:
+        # Clean properties (skip None)
+        properties = {
+            "PartiallyVerifies": ", ".join(partially_verifies)
+            if partially_verifies
+            else "",
+            "FullyVerifies": ", ".join(fully_verifies) if fully_verifies else "",
+            "TestType": test_type,
+            "DerivationTechnique": derivation_technique,
+        }
+        # Ensure a 'description' is there inside the Docstring
+        if not func.__doc__ or not func.__doc__.strip():
+            raise ValueError(
+                f"{func.__name__} does not have a description."
+                + "Descriptions (in docstrings) are mandatory."
+            )
+        # NOTE: This might come back to bite us in some weird edgecase, though I have not thought of one so far
+        # Remove keys with 'falsey' values
+        cleaned_properties = {k: v for k, v in properties.items() if v}
+        return pytest.mark.test_properties(cleaned_properties)(func)
+
+    return decorator
+
+
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) -> None:
+    """Attach file and line info to the report for use in junitxml output."""
+    if call.when != "call":
+        return
+    # Since our decorator 'add_test_properties' will create a 'test_properties' marker
+    # This function then searches for the nearest dictionary attached to an item with
+    # that marker and parses this into properties.
+
+    # In short:
+    #   => This function adds the properties specified via the decorator to the item so
+    #      they can be written to the XML output in the end
+    # Note: This does NOT add 'line' and 'file' to the testcase.
+
+    marker = item.get_closest_marker("test_properties")
+    if marker and isinstance(marker.args[0], dict):
+        for k, v in marker.args[0].items():
+            item.user_properties.append((k, str(v)))
+
+
+@pytest.fixture(autouse=True)
+def add_file_and_line_attr(
+    record_xml_attribute: Callable[[str, str], None], request: pytest.FixtureRequest
+) -> None:
+    """Adding line & file to the <testcase> attribute in the XML"""
+    node = request.node
+    raw_file_path, line_number, _ = node.location
+
+    # turning `../../../_main/<file_path>` into => <filepath>
+    clean_file_path = raw_file_path.split("_main/")[-1]
+    record_xml_attribute("file", str(clean_file_path))
+    # Adding +1 to the line so we point to the decorator instead of above it
+    record_xml_attribute("line", str(line_number + 1))

--- a/score_pytest/main.py
+++ b/score_pytest/main.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+import sys
+
+import pytest
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/score_pytest/py_pytest.bzl
+++ b/score_pytest/py_pytest.bzl
@@ -1,0 +1,57 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Bazel interface for running pytest"""
+
+load("@pip_tooling//:requirements.bzl", "all_requirements")
+load("@rules_python//python:defs.bzl", "py_test")
+
+def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugins = [], pytest_config = None, **kwargs):
+    pytest_bootstrap = Label("@score_tooling//python_basics/score_pytest:main.py")
+
+    if not pytest_config:
+        pytest_config = Label("@score_tooling//python_basics/score_pytest:pytest.ini")
+        #fail("$(location %s)" % pytest_config)
+
+    if not srcs:
+        fail("No source files provided for %s! (Is your glob empty?)" % name)
+
+    plugins = ["-p attribute_plugin"] + ["-p %s" % plugin for plugin in plugins]
+
+    py_test(
+        name = name,
+        srcs = [
+            pytest_bootstrap,
+        ] + srcs,
+        main = pytest_bootstrap,
+        args = [
+                   "-c $(location %s)" % pytest_config,
+                   "-p no:cacheprovider",
+
+                   # XML_OUTPUT_FILE: Location to which test actions should write a test
+                   # result XML output file. Otherwise, Bazel generates a default XML
+                   # output file wrapping the test log as part of the test action. The XML
+                   # schema is based on the JUnit test result schema.
+                   "--junitxml=$$XML_OUTPUT_FILE",
+               ] +
+               args +
+               plugins +
+               ["$(location %s)" % x for x in srcs],
+        deps = ["@score_tooling//python_basics/score_pytest:attribute_plugin"] + all_requirements + deps,
+        data = [
+            pytest_config,
+        ] + data,
+        env = env | {
+            "PYTHONDONOTWRITEBYTECODE": "1",
+        },
+        **kwargs
+    )

--- a/score_pytest/pytest.ini
+++ b/score_pytest/pytest.ini
@@ -40,17 +40,3 @@ junit_duration_report = call
 junit_family = xunit1
 filterwarnings =
     ignore::pytest.PytestExperimentalApiWarning
-
-    # Silence third-party deprecations from sphinx_needs targeting Python 3.14 removals.
-    # We'll drop these ignores once sphinx_needs releases a fix.
-    ignore:.*deprecated.*Python 3\.14.*:DeprecationWarning:sphinx_needs\..*
-
-    # Docutils is deprecating OptionParser in favor of argparse (0.21+).
-    # This one originates inside sphinx_needs.layout.
-    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
-    ignore:^The frontend\.OptionParser class will be replaced by a subclass of argparse\.ArgumentParser in Docutils 0\.21 or later\.:DeprecationWarning:sphinx_needs\.layout
-
-    # This one bubbles up from stdlib optparse but is *explicitly* a Docutils message.
-    # We match the full message to avoid silencing unrelated optparse warnings.
-    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
-    ignore:^The frontend\.Option class will be removed in Docutils 0\.21 or later\.:DeprecationWarning:optparse

--- a/score_pytest/pytest.ini
+++ b/score_pytest/pytest.ini
@@ -1,0 +1,56 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+[pytest]
+log_cli=True
+log_cli_level=Debug
+log_cli_format = [%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S
+
+log_format = [%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+
+log_file_level=Debug
+log_file_format = [%(asctime)s.%(msecs)03d] [%(levelname)-3s] [%(name)s] %(message)s
+log_file_date_format = %Y-%m-%d %H:%M:%S
+
+markers =
+    metadata
+    test_properties(dict): Add custom properties to test XML output
+
+# When executed directly without bazel, pytest will search everywhere for tests.
+# This is to prevent pytest from searching in directories that are not relevant.
+norecursedirs =
+  .*        # hidden folders like .git, .venv, .cache, etc.
+  _build*   # common docs-as-code directory
+  bazel-*   # Bazel output folders
+
+
+junit_duration_report = call
+junit_family = xunit1
+filterwarnings =
+    ignore::pytest.PytestExperimentalApiWarning
+
+    # Silence third-party deprecations from sphinx_needs targeting Python 3.14 removals.
+    # We'll drop these ignores once sphinx_needs releases a fix.
+    ignore:.*deprecated.*Python 3\.14.*:DeprecationWarning:sphinx_needs\..*
+
+    # Docutils is deprecating OptionParser in favor of argparse (0.21+).
+    # This one originates inside sphinx_needs.layout.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    ignore:^The frontend\.OptionParser class will be replaced by a subclass of argparse\.ArgumentParser in Docutils 0\.21 or later\.:DeprecationWarning:sphinx_needs\.layout
+
+    # This one bubbles up from stdlib optparse but is *explicitly* a Docutils message.
+    # We match the full message to avoid silencing unrelated optparse warnings.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    ignore:^The frontend\.Option class will be removed in Docutils 0\.21 or later\.:DeprecationWarning:optparse

--- a/score_pytest/tests/conftest.py
+++ b/score_pytest/tests/conftest.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+import pytest
+
+
+@pytest.fixture()
+def fixture42():
+    yield 42

--- a/score_pytest/tests/test_rules_are_working_correctly.py
+++ b/score_pytest/tests/test_rules_are_working_correctly.py
@@ -1,0 +1,14 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+def test_local_fixture_has_correct_value(fixture42):
+    assert fixture42 == 42

--- a/scripts_bazel/tests/BUILD
+++ b/scripts_bazel/tests/BUILD
@@ -12,9 +12,9 @@
 # *******************************************************************************
 
 load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
-load("@score_tooling//:defs.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
-score_py_pytest(
+score_pytest(
     name = "generate_sourcelinks_cli_test",
     srcs = ["generate_sourcelinks_cli_test.py"],
     deps = [
@@ -24,7 +24,7 @@ score_py_pytest(
     pytest_config = "//:pyproject.toml",
 )
 
-score_py_pytest(
+score_pytest(
     name = "merge_sourcelinks_test",
     srcs = ["merge_sourcelinks_test.py"],
     deps = [

--- a/src/extensions/score_header_service/BUILD
+++ b/src/extensions/score_header_service/BUILD
@@ -13,7 +13,7 @@
 
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
-load("@score_tooling//:defs.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
 filegroup(
     name = "all_sources",
@@ -30,7 +30,7 @@ py_library(
     deps = all_requirements,
 )
 
-score_py_pytest(
+score_pytest(
     name = "score_header_service_test",
     size = "small",
     srcs = glob(["test/**/*.py"]),

--- a/src/extensions/score_metamodel/BUILD
+++ b/src/extensions/score_metamodel/BUILD
@@ -13,7 +13,7 @@
 
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
-load("@score_tooling//:defs.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
 filegroup(
     name = "sources",
@@ -54,7 +54,7 @@ py_library(
     ],
 )
 
-score_py_pytest(
+score_pytest(
     name = "score_metamodel_tests",
     size = "small",
     srcs = glob(["tests/*.py"]),

--- a/src/extensions/score_source_code_linker/BUILD
+++ b/src/extensions/score_source_code_linker/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 load("@aspect_rules_py//py:defs.bzl", "py_library")
-load("@score_tooling//:defs.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
 filegroup(
     name = "sources",
@@ -61,7 +61,7 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
-score_py_pytest(
+score_pytest(
     name = "score_source_code_linker_test",
     size = "small",
     srcs = glob([

--- a/src/helper_lib/BUILD
+++ b/src/helper_lib/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
-load("@score_tooling//:defs.bzl", "score_py_pytest")
+load("//:score_pytest.bzl", "score_pytest")
 
 filegroup(
     name = "all_sources",
@@ -30,7 +30,7 @@ py_library(
     ] + all_requirements,
 )
 
-score_py_pytest(
+score_pytest(
     name = "helper_lib_tests",
     size = "small",
     srcs = ["test_helper_lib.py"],


### PR DESCRIPTION
Instead of relying on tooling, now docs_as_code defines, uses and provides its own `score_pytest` macro.