### PR TITLE
fix: support docs at root level

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -157,22 +157,28 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         deps = deps,
     )
 
+    # If the source directory is the root (".") we must omit it, otherwise:
+    # > invalid glob pattern './**/*.png': segment '.' not permitted
+    if source_dir == ".":
+        source_prefix = ""
+    else:
+        source_prefix = source_dir + "/"
+
     native.filegroup(
         name = "docs_sources",
         srcs = native.glob([
-            source_dir + "/**/*.png",
-            source_dir + "/**/*.svg",
-            source_dir + "/**/*.md",
-            source_dir + "/**/*.rst",
-            source_dir + "/**/*.html",
-            source_dir + "/**/*.css",
-            source_dir + "/**/*.puml",
-            source_dir + "/**/*.need",
-            source_dir + "/**/*.yaml",
-            source_dir + "/**/*.json",
-            source_dir + "/**/*.csv",
-            source_dir + "/**/*.inc",
-            "more_docs/**/*.rst",
+            source_prefix + "**/*.png",
+            source_prefix + "**/*.svg",
+            source_prefix + "**/*.md",
+            source_prefix + "**/*.rst",
+            source_prefix + "**/*.html",
+            source_prefix + "**/*.css",
+            source_prefix + "**/*.puml",
+            source_prefix + "**/*.need",
+            source_prefix + "**/*.yaml",
+            source_prefix + "**/*.json",
+            source_prefix + "**/*.csv",
+            source_prefix + "**/*.inc",
         ], allow_empty = True),
         visibility = ["//visibility:public"],
     )
@@ -280,7 +286,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
     sphinx_docs(
         name = "needs_json",
         srcs = [":docs_sources"],
-        config = ":" + source_dir + "/conf.py",
+        config = ":" + source_prefix + "conf.py",
         extra_opts = [
             "-W",
             "--keep-going",
@@ -298,15 +304,6 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         allow_persistent_workers = False,
     )
 
-    sphinx_module(
-        name = native.module_name() + "_module",
-        srcs = [":docs_sources"],
-        # config = ":" + source_dir + "/conf.py",
-        index = source_dir + "/index.rst",
-        sphinx = "@score_tooling//bazel/rules/rules_score:score_build",
-        deps = module_deps,
-        visibility = ["//visibility:public"],
-    )
 
 def _sourcelinks_json(name, srcs):
     """


### PR DESCRIPTION
docs at root level are impossible without this change

note: merge https://github.com/eclipse-score/docs-as-code/pull/481 first