### PR TITLE
Actually --known_good is not required

### DIFF
--- a/scripts_bazel/merge_sourcelinks.py
+++ b/scripts_bazel/merge_sourcelinks.py
@@ -39,7 +39,6 @@ def main():
     )
     _ = parser.add_argument(
         "--known_good",
-        required=True,
         help="Path to a required 'known good' JSON file (provided by Bazel).",
     )
     _ = parser.add_argument(


### PR DESCRIPTION
Fixes breaking logging: https://github.com/eclipse-score/logging/actions/runs/24405821314/job/71288707509

```
ERROR: /home/runner/work/logging/logging/BUILD:49:5: Executing genrule //:merged_sourcelinks failed: (Exit 2): bash failed: error executing Genrule command (from target //:merged_sourcelinks) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
usage: merge_sourcelinks.py [-h] --output OUTPUT --known_good KNOWN_GOOD
                            [files ...]
merge_sourcelinks.py: error: the following arguments are required: --known_good
```