### PR TITLE
Fix for CPP literal include

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -46,28 +46,28 @@ load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 
 def _rewrite_needs_json_to_docs_sources(labels):
-    """Replace '@repo//:needs_json' -> '@repo//:docs_sources' for every item.
-       Note: Else path has been commented out as this prevented inclusion of CPP files
-       for case when fragment of code shall be displayed as literal include.
-    """
+    """Replace '@repo//:needs_json' -> '@repo//:docs_sources' for every item."""
     out = []
     for x in labels:
         s = str(x)
         if s.endswith("//:needs_json"):
             out.append(s.replace("//:needs_json", "//:docs_sources"))
-        #else:
-            #out.append(s)
+        else:
+            out.append(s)
     return out
 
 def _rewrite_needs_json_to_sourcelinks(labels):
-    """Replace '@repo//:needs_json' -> '@repo//:sourcelinks_json' for every item."""
+    """Replace '@repo//:needs_json' -> '@repo//:sourcelinks_json' for every item.
+        Note: Else path has been commented out as this prevented inclusion of CPP files
+        for case when fragment of code shall be displayed as literal include.
+    """
     out = []
     for x in labels:
         s = str(x)
         if s.endswith("//:needs_json"):
             out.append(s.replace("//:needs_json", "//:sourcelinks_json"))
-        else:
-            out.append(s)
+        #else:
+            #out.append(s)
     return out
 
 def _merge_sourcelinks(name, sourcelinks, known_good = None):

--- a/docs.bzl
+++ b/docs.bzl
@@ -57,17 +57,14 @@ def _rewrite_needs_json_to_docs_sources(labels):
     return out
 
 def _rewrite_needs_json_to_sourcelinks(labels):
-    """Replace '@repo//:needs_json' -> '@repo//:sourcelinks_json' for every item.
-        Note: Else path has been commented out as this prevented inclusion of CPP files
-        for case when fragment of code shall be displayed as literal include.
-    """
+    """Replace '@repo//:needs_json' -> '@repo//:sourcelinks_json' for every item."""
     out = []
     for x in labels:
         s = str(x)
         if s.endswith("//:needs_json"):
             out.append(s.replace("//:needs_json", "//:sourcelinks_json"))
-        #else:
-            #out.append(s)
+        #Items which do not end up with '//:needs_json' shall not be appended to 'out'.
+        #They are treated separately and are not related to source code linking.
     return out
 
 def _merge_sourcelinks(name, sourcelinks, known_good = None):

--- a/docs.bzl
+++ b/docs.bzl
@@ -46,14 +46,17 @@ load("@docs_as_code_hub_env//:requirements.bzl", "all_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 
 def _rewrite_needs_json_to_docs_sources(labels):
-    """Replace '@repo//:needs_json' -> '@repo//:docs_sources' for every item."""
+    """Replace '@repo//:needs_json' -> '@repo//:docs_sources' for every item.
+       Note: Else path has been commented out as this prevented inclusion of CPP files
+       for case when fragment of code shall be displayed as literal include.
+    """
     out = []
     for x in labels:
         s = str(x)
         if s.endswith("//:needs_json"):
             out.append(s.replace("//:needs_json", "//:docs_sources"))
-        else:
-            out.append(s)
+        #else:
+            #out.append(s)
     return out
 
 def _rewrite_needs_json_to_sourcelinks(labels):


### PR DESCRIPTION
## 📌 Description
Filtering only for needs.json has prevented exporting of the CPP files which shall be displayed as literal include in the documentation. Eg. API Usage with corresponding example. 

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
