### PR TITLE
try using harden-runner in doc as code

### DIFF
--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -27,7 +27,14 @@ jobs:
       matrix:
         consumer: ["process_description", "score", "module_template"]
 
+
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
+
       - name: Checkout PR
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -26,6 +26,11 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,6 +22,11 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
   code:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -21,6 +21,11 @@ jobs:
     outputs:
       should_create_issue: ${{ steps.detect.outputs.issue_needed }}
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 


### PR DESCRIPTION
Description
Add security hardening step to GitHub workflows

This PR adds the step-security/harden-runner@v2.18.0 action to 6 GitHub workflows to improve the security posture of the Eclipse SCORE project. The hardening runner monitors and audits egress (outbound) network traffic from CI/CD jobs, helping to detect and prevent unauthorized or suspicious network activity.

Modified workflows:

consumer_test.yml
link_check.yml
lint.yml
renovate.yml
test.yml
test_links.yml
Key implementation details:

Conditional execution: Only runs when github.repository_owner == 'eclipse-score' (does not affect forks)
Egress policy set to audit (non-blocking, monitoring mode)
Positioned as the first step in each job for maximum effectiveness

Impact Analysis
 This change does not violate any tool requirements and is covered by existing tool requirements
 This change does not violate any design decisions
 Otherwise I have created a ticket for new tool qualification
Rationale: This is a security enhancement that adds monitoring without modifying workflow behavior. No new tools or dependencies are introduced that would violate existing requirements.

✅ Checklist
 Added/updated documentation for new or changed features
(Documentation: Changes are self-contained in workflow definitions with descriptive step name)
 Added/updated tests to cover the changes
(Not applicable: Workflow changes; no unit tests needed)
 Followed project coding standards and guidelines
(Consistent YAML formatting and follows GitHub Actions best practices)
