### PR TITLE
docs: update stale bazel_dep versions in how-to guides

### DIFF
--- a/docs/how-to/other_modules.rst
+++ b/docs/how-to/other_modules.rst
@@ -35,7 +35,7 @@ A minimal example (add or extend the existing `bazel_deps` stanza):
 
 .. code-block:: starlark
 
-	 bazel_dep(name = "score_process", version = "1.3.0")
+	 bazel_dep(name = "score_process", version = "1.5.3")
 
 2) Extend your `docs` rule so Sphinx picks up the other module's inventory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/setup.md
+++ b/docs/how-to/setup.md
@@ -23,7 +23,7 @@ designed to enhance documentation capabilities in S-CORE.
 Add the module to your `MODULE.bazel` file:
 
 ```starlark
-bazel_dep(name = "score_docs_as_code", version = "2.0.3")
+bazel_dep(name = "score_docs_as_code", version = "4.0.1")
 ```
 
 And make sure to also add the S-core Bazel registry to your `.bazelrc` file


### PR DESCRIPTION
## Summary

- Bump `score_docs_as_code` `2.0.3` → `4.0.1` in `docs/how-to/setup.md`
- Bump `score_process` `1.3.0` → `1.5.3` in `docs/how-to/other_modules.rst`

The version examples in the how-to guides were significantly out of date. Versions verified against the [eclipse-score bazel_registry](https://github.com/eclipse-score/bazel_registry).

## Test plan

- [x] Verify rendered docs still look correct
- [x] Confirm versions match the latest entries in the bazel registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)