### PR TITLE
try using harden-runner

### DIFF
--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -28,6 +28,12 @@ jobs:
         consumer: ["process_description", "score", "module_template"]
 
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
+
       - name: Checkout PR
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -26,6 +26,11 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,6 +22,11 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
   code:
     runs-on: ubuntu-latest
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository (Handle all events)
         uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/test_links.yml
+++ b/.github/workflows/test_links.yml
@@ -21,6 +21,11 @@ jobs:
     outputs:
       should_create_issue: ${{ steps.detect.outputs.issue_needed }}
     steps:
+      - name: 🛡️ Harden Runner
+        if: github.repository_owner == 'eclipse-score'
+        uses: step-security/harden-runner@v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 


### PR DESCRIPTION

his PR adds the step-security/harden-runner@v2.18.0 action to 6 GitHub workflows to improve the security posture of the Eclipse SCORE project. The hardening runner monitors and audits egress (outbound) network traffic from CI/CD jobs, helping to detect and prevent unauthorized or suspicious network activity.

Note: some issue with old PR with USER info ref https://github.com/eclipse-score/docs-as-code/pull/504

because of that am creating new one. 



