### PR TITLE
fix: FMEA can also link to static architecture views

### DIFF
--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -812,7 +812,7 @@ needs_types:
       mitigation_issue: ^https://github.com/.*$
     mandatory_links:
       # req-Id: tool_req__docs_saf_attrs_violates
-      violates: feat_arc_dyn
+      violates: feat_arc_dyn, feat_arc_sta
     optional_links:
       # req-Id: tool_req__docs_saf_attrs_mitigated_by
       # (only mandatory once valid status == valid)
@@ -839,7 +839,7 @@ needs_types:
       mitigation_issue: ^https://github.com/.*$
     mandatory_links:
       # req-Id: tool_req__docs_saf_attrs_violates
-      violates: comp_arc_dyn
+      violates: comp_arc_dyn, comp_arc_sta
     optional_links:
       mitigated_by: comp_req, aou_req
     tags:

--- a/src/extensions/score_metamodel/tests/rst/options/test_options_options.rst
+++ b/src/extensions/score_metamodel/tests/rst/options/test_options_options.rst
@@ -190,15 +190,33 @@
 
 
 
+--- feat_saf_fmea violates begin ---
+
 .. Negative Test: Linked to a non-allowed requirement type.
-#EXPECT: feat_saf_fmea__child__26: references 'comp_req__child__ASIL_B' as 'violates', but it must reference Feature Sequence Diagram (feat_arc_dyn).
+#EXPECT: feat_saf_fmea__child__26: references 'comp_req__child__ASIL_B' as 'violates', but it must reference Feature Sequence Diagram (feat_arc_dyn) or Feature & Feature Package Diagram (feat_arc_sta).
 
 .. feat_saf_fmea:: Child requirement 26
    :id: feat_saf_fmea__child__26
-   :safety: ASIL_B
-   :status: valid
    :violates: comp_req__child__ASIL_B
 
+.. feat_saf_fmea can link either feat_arc_dyn or feat_arc_sta
+
+Expect no errors related to "violates" field. We need to be generic for expect-not verifications.
+#EXPECT-NOT: violates
+
+.. feat_saf_fmea:: This requirement links a feat_arc_dyn
+   :id: feat_saf_fmea__violate__dyn
+   :violates: feat_arc_dyn__test_good_1
+
+
+Expect no errors related to "violates" field. We need to be generic for expect-not verifications.
+#EXPECT-NOT: violates
+
+.. feat_saf_fmea:: This requirement links a feat_arc_sta
+   :id: feat_saf_fmea__violate__sta
+   :violates: feat_arc_sta__test_good_1
+
+--- feat_saf_fmea violates end ---
 
 
 .. Tests if the attribute `safety` follows the pattern `^(QM|ASIL_B)$`


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
Add links from FMEA to static architecture views as agreed in https://github.com/orgs/eclipse-score/discussions/2234#discussioncomment-16682851

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification
tool_req__docs_saf_attrs_violates has to be adapted but is stated as not implemented

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features - covered by safety analysis process
- [ ] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
