### PR TITLE
add parent_need to default options

### DIFF
--- a/src/extensions/score_metamodel/yaml_parser.py
+++ b/src/extensions/score_metamodel/yaml_parser.py
@@ -95,6 +95,9 @@ def default_options():
         # Introduced with sphinx-needs 6.3.0
         "is_import",
         "constraints",
+        # Added by sphinx-needs when needs are imported via needimport
+        "parent_needs",
+        "parent_need",
     }
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
add parent_need to default options to fix warings that show up when needimport is used
https://github.com/eclipse-score/score/pull/2789

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [ ] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
