### PR TITLE
Feat: Change color of table headers in light mode

### DIFF
--- a/src/extensions/score_layout/assets/css/score.css
+++ b/src/extensions/score_layout/assets/css/score.css
@@ -29,6 +29,7 @@ html[data-theme="light"] {
     --pst-color-muted: #FFF;
     /* Text color within cards (same background as page header) */
     --sd-color-card-text: #a382c5;
+    /* Text color for table captions (same background as page header) */
     /* Link color + menu items on hover color */
     --pst-color-primary: #7c4daa;
     /* Page Header */
@@ -37,7 +38,7 @@ html[data-theme="light"] {
     --pst-color-target: #E5FCC2;
     --pst-color-on-surface: #594F4F;
     --pst-color-on-background: var(--pst-color-secondary);
-    --pst-color-text-muted: #FFFFFF;
+    --pst-color-text-muted: #a382c5;
     --pst-color-table-row-zebra-high-bg: #e6e7e8;
     --pst-color-table-row-hover-bg: var(--pst-color-secondary); /*#d7d6d6;*/
 }


### PR DESCRIPTION
## 📌 Description
Fixes #529 

"Black" text is not possible, as the css selector of the table captions is shared with the nav elements. If we make it black you can not read the nav elements anymore. 
=> Now looks like: 
<img width="3063" height="1453" alt="image" src="https://github.com/user-attachments/assets/c220c9d2-daaf-454b-9eca-424303fd0f0c" />


## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [ ] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
