### PR TITLE
fix: make table captions visible in light mode

### DIFF
--- a/src/extensions/score_layout/assets/css/score.css
+++ b/src/extensions/score_layout/assets/css/score.css
@@ -143,6 +143,13 @@ blockquote {
     color: var(--pst-color-text-base);
 }
 
+/* Override text-muted for content-area elements that need readable text on light backgrounds.
+   --pst-color-text-muted is set to #FFF for the dark header, but these sit on the page body. */
+html[data-theme="light"] table caption,
+html[data-theme="light"] figure figcaption {
+    color: var(--pst-color-text-base);
+}
+
 .admonition, div.admonition {
     background-color: rgba(0,0,0,0.1);
 }


### PR DESCRIPTION
## Summary

- Fixes table captions and figure captions being invisible in light mode (white text on light background)
- Adds targeted CSS overrides for `table caption` and `figure figcaption` in light mode instead of changing the shared `--pst-color-text-muted` variable
- Keeps the header/nav styling untouched

## Root cause

The pydata-sphinx-theme styles `table caption` and `figure figcaption` with `var(--pst-color-text-muted)`. The SCORE theme overrides this variable to `#FFFFFF` for the dark header background — but this bleeds into content-area elements sitting on a light page body.

## Why not change the variable?

PR #534 changes `--pst-color-text-muted` from `#FFFFFF` to `#a382c5` globally, which fixes captions but recolors ~20 other elements including header nav links, the SCORE brand text, navbar icons, search elements, etc.

This PR instead follows the existing pattern in `score.css` — the file already overrides `blockquote`, breadcrumbs, sidebar links, and prev/next navigation to `--pst-color-text-base` for the same reason.

Fixes #529
Supersedes #534