### PR TITLE
Add valid only allowed to link to valid check

### DIFF
--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -23,7 +23,7 @@ from score_metamodel import (
 from sphinx.application import Sphinx
 from sphinx_needs.config import NeedType
 from sphinx_needs.data import NeedsView
-from sphinx_needs.need_item import NeedItem, NeedLink
+from sphinx_needs.need_item import NeedItem
 
 
 def eval_need_check(need: NeedItem, check: str, log: CheckLogger) -> bool:

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -226,5 +226,5 @@ def check_valid_only_links_to_valid(
         )
         invalid_needs = all_linked_needs.difference(valid_needs_id_all)
         if invalid_needs:
-            msg = f"Is valid but links to invalid need(s): {invalid_needs}"
+            msg = f"is valid but links to invalid need(s): {invalid_needs}"
             log.warning_for_need(need, msg, is_new_check=True)

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import operator
+from itertools import chain
 from collections.abc import Callable
 from functools import reduce
 from typing import Any, cast
@@ -22,7 +23,7 @@ from score_metamodel import (
 from sphinx.application import Sphinx
 from sphinx_needs.config import NeedType
 from sphinx_needs.data import NeedsView
-from sphinx_needs.need_item import NeedItem
+from sphinx_needs.need_item import NeedItem, NeedLink
 
 
 def eval_need_check(need: NeedItem, check: str, log: CheckLogger) -> bool:
@@ -198,3 +199,28 @@ def check_metamodel_graph(
                             f" Explanation: {explanation}"
                         )
                         log.warning_for_need(need, msg)
+
+
+@graph_check
+def check_valid_only_links_to_valid(
+    app: Sphinx,
+    all_needs: NeedsView,
+    log: CheckLogger,
+):
+    # Get all possible link types
+    needs_dict_all = {need["id"]: need for need in all_needs.values()}
+    needs_dict_local = {
+        need["id"]: need for need in all_needs.filter_is_external(False).values()
+    }
+    # Pre-Filter for only valid & local needs
+    valid_needs_id_all = [x.id for x in all_needs.values() if x.get("status") == "valid"]
+    valid_needs_local = [
+        x for x in all_needs.filter_is_external(False).values() if x.get("status") == "valid"
+    ]
+
+    for need in valid_needs_local:
+        all_linked_needs: list[NeedLink] = list(chain(*need._links.values()))  # type: ignore
+        for link in all_linked_needs:
+            if link.id not in valid_needs_id_all:
+                msg = f"Is valid but links to invalid need: {link.id}"
+                log.warning_for_need(need, msg, is_new_check=True)

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -207,11 +207,11 @@ def check_valid_only_links_to_valid(
     all_needs: NeedsView,
     log: CheckLogger,
 ):
-    # Get all possible link types
-    # Pre-Filter for only valid & local needs
-    valid_needs_id_all = [
+    # Pre-Gather all *valid* need id's (external, & local)
+    valid_needs_id_all = set(
         x.id for x in all_needs.values() if x.get("status") == "valid"
-    ]
+    )
+    # Pre-Gather all LOCAL *valid* id's to iterate over and check
     valid_needs_local = [
         x
         for x in all_needs.filter_is_external(False).values()
@@ -219,8 +219,12 @@ def check_valid_only_links_to_valid(
     ]
 
     for need in valid_needs_local:
-        all_linked_needs: list[NeedLink] = list(chain(*need._links.values()))  # type: ignore
-        for link in all_linked_needs:
-            if link.id not in valid_needs_id_all:
-                msg = f"Is valid but links to invalid need: {link.id}"
-                log.warning_for_need(need, msg, is_new_check=True)
+        # Using set comprehension here to enable faster computation for comparisons
+        all_linked_needs: set[str] = set(
+            x.id
+            for x in set(chain(*need._links.values()))  # type: ignore
+        )
+        invalid_needs = all_linked_needs.difference(valid_needs_id_all)
+        if invalid_needs:
+            msg = f"Is valid but links to invalid need(s): {invalid_needs}"
+            log.warning_for_need(need, msg, is_new_check=True)

--- a/src/extensions/score_metamodel/checks/graph_checks.py
+++ b/src/extensions/score_metamodel/checks/graph_checks.py
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import operator
-from itertools import chain
 from collections.abc import Callable
 from functools import reduce
+from itertools import chain
 from typing import Any, cast
 
 from score_metamodel import (
@@ -208,14 +208,14 @@ def check_valid_only_links_to_valid(
     log: CheckLogger,
 ):
     # Get all possible link types
-    needs_dict_all = {need["id"]: need for need in all_needs.values()}
-    needs_dict_local = {
-        need["id"]: need for need in all_needs.filter_is_external(False).values()
-    }
     # Pre-Filter for only valid & local needs
-    valid_needs_id_all = [x.id for x in all_needs.values() if x.get("status") == "valid"]
+    valid_needs_id_all = [
+        x.id for x in all_needs.values() if x.get("status") == "valid"
+    ]
     valid_needs_local = [
-        x for x in all_needs.filter_is_external(False).values() if x.get("status") == "valid"
+        x
+        for x in all_needs.filter_is_external(False).values()
+        if x.get("status") == "valid"
     ]
 
     for need in valid_needs_local:

--- a/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
@@ -1,0 +1,29 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+.. #CHECK: check_valid_only_links_to_valid
+
+.. feat_req:: Parent requirement INVALID QM
+   :id: feat_req__parent__QM_invalid
+   :safety: QM
+   :status: invalid
+
+.. We can not yet enable this test. As the check is only an 'info' and not yet a true warning
+.. #EXPECT: comp_saf_fmea__child__16: is valid but links to invalid need:
+
+.. comp_saf_fmea:: Child requirement 
+   :id: comp_saf_fmea__child__1
+   :safety: QM
+   :status: valid
+   :mitigated_by: feat_req__parent__QM_invalid

--- a/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
@@ -22,7 +22,7 @@
 .. We can not yet enable this test. As the check is only an 'info' and not yet a true warning
 .. #EXPECT: comp_saf_fmea__child__16: is valid but links to invalid need:
 
-.. comp_saf_fmea:: Child requirement 
+.. comp_saf_fmea:: Child requirement
    :id: comp_saf_fmea__child__1
    :safety: QM
    :status: valid

--- a/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_invalid_graph.rst
@@ -12,7 +12,7 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-.. #CHECK: check_valid_only_links_to_valid
+#CHECK: check_valid_only_links_to_valid
 
 .. feat_req:: Parent requirement INVALID QM
    :id: feat_req__parent__QM_invalid
@@ -20,7 +20,10 @@
    :status: invalid
 
 .. We can not yet enable this test. As the check is only an 'info' and not yet a true warning
-.. #EXPECT: comp_saf_fmea__child__16: is valid but links to invalid need:
+.. Therefore the test is the inverse of what we will test once it is enabled.
+
+.. #EXPECT: comp_saf_fmea__child__16: is valid but links to invalid need(s):
+#EXPECT-NOT: invalid need(s):
 
 .. comp_saf_fmea:: Child requirement
    :id: comp_saf_fmea__child__1

--- a/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
@@ -186,3 +186,5 @@
    :safety: ASIL_B
    :status: valid
    :mitigated_by: feat_req__parent__ASIL_B
+
+

--- a/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
+++ b/src/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
@@ -186,5 +186,3 @@
    :safety: ASIL_B
    :status: valid
    :mitigated_by: feat_req__parent__ASIL_B
-
-


### PR DESCRIPTION
## 📌 Description
Add valid only allowed to link to valid check

The test is currently only a 'soft warning' and not enabled. (is_new_check =true). 
In future releases this should be enabled and the RST based tests enbaled as well as the metamodel.yaml graph based tests adapted. 


## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
