### PR TITLE
feat: support no-java repos

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -125,7 +125,7 @@ def _missing_requirements(deps):
         fail(msg)
     fail("This case should be unreachable?!")
 
-def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good = None, metamodel = None):
+def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good = None, metamodel = None, plantuml = True):
     """Creates all targets related to documentation.
 
     By using this function, you'll get any and all updates for documentation targets in one place.
@@ -138,6 +138,10 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
       known_good: Optional label to a "known good" JSON file for source links.
       metamodel: Optional label to a metamodel.yaml file. When set, the extension loads this
                  file instead of the default metamodel shipped with score_metamodel.
+      plantuml: Whether to include PlantUML support. Requires Java. Defaults to True.
+                Set to False to skip the PlantUML dependency entirely.
+                Note: this only makes sense if you do not use any Java at all
+                (rules_java pulls Java only if a Java target is in the dependency graph).
     """
 
     call_path = native.package_name()
@@ -155,10 +159,15 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
 
     module_deps = deps
     deps = deps + _missing_requirements(deps)
-    deps = deps + [
-        "@score_docs_as_code//src:plantuml_for_python",
-        "@score_docs_as_code//src/extensions/score_sphinx_bundle:score_sphinx_bundle",
-    ]
+
+    if plantuml:
+        plantuml_dep = ["@score_docs_as_code//src:plantuml_for_python"]
+        plantuml_env = {"SCORE_PLANTUML_ENABLED": "1"}
+    else:
+        plantuml_dep = []
+        plantuml_env = {"SCORE_PLANTUML_ENABLED": "0"}
+
+    deps = deps + plantuml_dep + ["@score_docs_as_code//src/extensions/score_sphinx_bundle:score_sphinx_bundle"]
 
     sphinx_build_binary(
         name = "sphinx_build",
@@ -205,12 +214,13 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         "SOURCE_DIRECTORY": source_dir,
         "DATA": str(data),
         "SCORE_SOURCELINKS": "$(location :sourcelinks_json)",
-    } | metamodel_env
+    } | metamodel_env | plantuml_env
     docs_sources_env = {
         "SOURCE_DIRECTORY": source_dir,
         "DATA": str(data_with_docs_sources),
         "SCORE_SOURCELINKS": "$(location :merged_sourcelinks)",
-    } | metamodel_env
+    } | metamodel_env | plantuml_env
+
     if known_good:
         docs_env["KNOWN_GOOD_JSON"] = "$(location "+ known_good + ")"
         docs_sources_env["KNOWN_GOOD_JSON"] = "$(location "+ known_good + ")"

--- a/src/extensions/score_plantuml.py
+++ b/src/extensions/score_plantuml.py
@@ -53,13 +53,17 @@ def find_correct_path(runfiles: Path) -> Path:
 
 
 def setup(app: Sphinx):
-    # we must overwrite the plantuml path due to Bazel
-    app.config.plantuml = str(find_correct_path(get_runfiles_dir()))
-    config_setdefault(app.config, "plantuml_output_format", "svg_obj")
-    config_setdefault(app.config, "plantuml_syntax_error_image", True)
-    config_setdefault(app.config, "needs_build_needumls", "_plantuml_sources")
+    plantuml_path = find_correct_path(get_runfiles_dir())
+    if not plantuml_path.exists():
+        logger.debug("PlantUML binary not found in runfiles, skipping PlantUML setup")
+    else:
+        # we must overwrite the plantuml path due to Bazel
+        app.config.plantuml = str(plantuml_path)
+        config_setdefault(app.config, "plantuml_output_format", "svg_obj")
+        config_setdefault(app.config, "plantuml_syntax_error_image", True)
+        config_setdefault(app.config, "needs_build_needumls", "_plantuml_sources")
 
-    logger.debug(f"PlantUML binary found at {app.config.plantuml}")
+        logger.debug(f"PlantUML binary found at {app.config.plantuml}")
 
     # The extension is not even active at runtime.
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/src/extensions/score_sphinx_bundle/__init__.py
+++ b/src/extensions/score_sphinx_bundle/__init__.py
@@ -10,16 +10,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+import os
+
 from sphinx.application import Sphinx
 
 from src.helper_lib import config_setdefault
 
+# Is PlantUML support enabled? Defaults to True to avoid any problems.
+_plantuml_enabled = os.environ.get("SCORE_PLANTUML_ENABLED", "1") != "0"
+
 # Note: order matters!
 # Extensions are loaded in this order.
 # e.g. plantuml MUST be loaded before sphinx-needs
-score_extensions = [
-    "sphinxcontrib.plantuml",
-    "score_plantuml",
+plantuml_extensions = (
+    ["sphinxcontrib.plantuml", "score_plantuml"] if _plantuml_enabled else []
+)
+
+score_extensions = plantuml_extensions + [
     "sphinx_needs",
     "score_metamodel",
     "sphinx_design",


### PR DESCRIPTION
Currently docs cannot be used without Java. For repos that do not use any uml, this is just overhead that is downloaded all the time, but never actually used.

Downside: potential issues when such repos do want to use plantuml and wonder why its not working.