### PR TITLE
feat: Provide :metrics_json target

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -316,10 +316,18 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         allow_persistent_workers = False,
     )
 
+    native.genrule(
+        name = "metrics_json",
+        srcs = [":needs_json"],
+        outs = ["metrics.json"],
+        cmd = "cp $(location :needs_json)/metrics.json $@",
+        visibility = ["//visibility:public"],
+    )
+
     native.alias(
         name = "traceability_gate",
         actual = "@score_docs_as_code//scripts_bazel:traceability_gate",
-        tags = ["cli_help=Enforce traceability coverage thresholds:\nbazel run //:traceability_gate -- --metrics-json bazel-bin/needs_json/_build/needs/metrics.json"],
+        tags = ["cli_help=Enforce traceability coverage thresholds:\nbazel run //:traceability_gate -- --metrics-json $(location //:metrics_json)"],
     )
 
 def _sourcelinks_json(name, srcs):


### PR DESCRIPTION
With this Bazel rules can depend on exactly that file instead of somehow extracting it from :needs_json in hacky ways.

This seems to be the cleanest way, because we cannot change the sphinx_docs rule to add additional special outputs.
