### PR TITLE
test: avoid chdir by passing git_root

### DIFF
--- a/src/extensions/score_source_code_linker/helpers.py
+++ b/src/extensions/score_source_code_linker/helpers.py
@@ -35,7 +35,8 @@ def get_github_link(
     """
     Get GitHub link for a file and line number using git information from the local repository.
 
-    @param git_root: Optional path to the git repository root. If not provided, it will be auto-detected.
+    Args:
+        git_root: Optional path to the git repository root. If not provided, it will be auto-detected.
     """
     if link is None:
         link = DefaultNeedLink()

--- a/src/extensions/score_source_code_linker/helpers.py
+++ b/src/extensions/score_source_code_linker/helpers.py
@@ -30,26 +30,32 @@ from src.helper_lib import (
 def get_github_link(
     metadata: RepoInfo,
     link: NeedLink | DataForTestLink | DataOfTestCase | None = None,
+    git_root: Path | None = None,
 ) -> str:
+    """
+    Get GitHub link for a file and line number using git information from the local repository.
+
+    @param git_root: Optional path to the git repository root. If not provided, it will be auto-detected.
+    """
     if link is None:
         link = DefaultNeedLink()
     if not metadata.hash:
+        if not git_root:
+            git_root = find_git_root() or Path()
         # Local path (//:docs)
-        return get_github_link_from_git(link)
+        return get_github_link_from_git(git_root, link)
     # Ref-Integration path (//:docs_combo..)
     return get_github_link_from_json(metadata, link)
 
 
 def get_github_link_from_git(
+    git_root: Path,
     link: NeedLink | DataForTestLink | DataOfTestCase | None = None,
 ) -> str:
     if link is None:
         link = DefaultNeedLink()
-    passed_git_root = find_git_root()
-    if passed_git_root is None:
-        passed_git_root = Path()
-    base_url = get_github_base_url()
-    current_hash = get_current_git_hash(passed_git_root)
+    base_url = get_github_base_url(git_root)
+    current_hash = get_current_git_hash(git_root)
     return f"{base_url}/blob/{current_hash}/{link.file}#L{link.line}"
 
 

--- a/src/extensions/score_source_code_linker/tests/test_codelink.py
+++ b/src/extensions/score_source_code_linker/tests/test_codelink.py
@@ -16,7 +16,6 @@
 # ╙                                                          ╜
 
 import json
-import os
 import subprocess
 import tempfile
 from collections.abc import Generator
@@ -506,11 +505,9 @@ def another_function():
             assert len(found_links.links.TestLinks) == 0
 
     # Test GitHub link generation
-    # Have to change directories in order to ensure that we get the right/any .git file
-    os.chdir(Path(git_repo).absolute())
     metadata = RepoInfo(name="local_repo", hash="", url="")
     for needlink in loaded_links:
-        github_link = get_github_link(metadata, needlink)
+        github_link = get_github_link(metadata, needlink, git_root=git_repo)
         assert "https://github.com/test-user/test-repo/blob/" in github_link
         assert f"src/{needlink.file.name}#L{needlink.line}" in github_link
 
@@ -545,8 +542,7 @@ def test_multiple_commits_hash_consistency(git_repo: Path) -> None:
     )
 
     metadata = RepoInfo(name="local_repo", hash="", url="")
-    os.chdir(Path(git_repo).absolute())
-    github_link = get_github_link(metadata, needlink)
+    github_link = get_github_link(metadata, needlink, git_root=git_repo)
     assert new_hash in github_link
 
 

--- a/src/extensions/score_source_code_linker/tests/test_helpers.py
+++ b/src/extensions/score_source_code_linker/tests/test_helpers.py
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import json
-import os
 import subprocess
 import tempfile
 from collections.abc import Generator
@@ -370,7 +369,6 @@ def git_repo(temp_dir: Path) -> Path:
 def test_get_github_link_with_real_repo(git_repo: Path) -> None:
     """
     Test generating GitHub link without url/hash.
-    This expects to be in a git repo
     """
     metadata = RepoInfo(name="some_repo", url="", hash="")
 
@@ -378,10 +376,7 @@ def test_get_github_link_with_real_repo(git_repo: Path) -> None:
     link.file = Path("src/example.py")
     link.line = 42
 
-    # Have to change directories in order to ensure that we get the right/any .git file
-    os.chdir(Path(git_repo).absolute())
-    # ADAPTED: Using get_github_link_from_git for direct local repo testing
-    result = get_github_link(metadata, link)
+    result = get_github_link(metadata, link, git_root=git_repo)
 
     # Should contain the base URL, hash, file path, and line number
     assert "https://github.com/test-user/test-repo/blob/" in result

--- a/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
@@ -213,7 +213,6 @@ def make_test_xml_2():
 # flake8: noqa: E501 (end)
 
 
-
 @pytest.fixture()
 def sphinx_app_setup(
     sphinx_base_dir: Path, create_demo_files: None, git_repo_setup: Path

--- a/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
@@ -38,7 +38,7 @@ from src.extensions.score_source_code_linker.tests.test_codelink import (
 from src.extensions.score_source_code_linker.tests.test_need_source_links import (
     SourceCodeLinks_TEST_JSON_Decoder,
 )
-from src.helper_lib import find_ws_root, get_github_base_url
+from src.helper_lib import find_ws_root
 
 
 @pytest.fixture(scope="session")
@@ -212,10 +212,6 @@ def make_test_xml_2():
 
 # flake8: noqa: E501 (end)
 
-
-def construct_gh_url() -> str:
-    gh = get_github_base_url()
-    return f"{gh}/blob/"
 
 
 @pytest.fixture()

--- a/src/helper_lib/__init__.py
+++ b/src/helper_lib/__init__.py
@@ -138,7 +138,7 @@ def get_github_base_url(git_root: Path) -> str:
 
     Execution context behavior:
     - 'bazel run' => ✅ Correct GitHub URL
-    - 'bazel build' => ⚠️ Uses Path() fallback when git_root is None
+    - 'bazel build' => ⚠️ git_root must be provided by the caller; no auto-detection here
     - 'direct sphinx' => ✅ Correct GitHub URL
 
     Returns:

--- a/src/helper_lib/__init__.py
+++ b/src/helper_lib/__init__.py
@@ -132,7 +132,7 @@ def get_github_repo_info(git_root_cwd: Path) -> str:
     return repo
 
 
-def get_github_base_url() -> str:
+def get_github_base_url(git_root: Path) -> str:
     """
     Generate GitHub base URL for the current repository.
 
@@ -144,10 +144,7 @@ def get_github_base_url() -> str:
     Returns:
         GitHub URL in format 'https://github.com/user/repo'
     """
-    passed_git_root = find_git_root()
-    if passed_git_root is None:
-        passed_git_root = Path()
-    repo_info = get_github_repo_info(passed_git_root)
+    repo_info = get_github_repo_info(git_root)
     return f"https://github.com/{repo_info}"
 
 

--- a/src/tests/test_consumer.py
+++ b/src/tests/test_consumer.py
@@ -550,7 +550,7 @@ def setup_test_environment(sphinx_base_dir: Path, pytestconfig: Config):
 
     assert git_root, "Git root was not found"
 
-    gh_url = get_github_base_url()
+    gh_url = get_github_base_url(git_root)
     current_hash = get_current_git_commit(git_root)
 
     os.chdir(Path(sphinx_base_dir).absolute())


### PR DESCRIPTION
`chdir` is a major driver for inter-test dependencies. One order of tests works, another does not. This PR avoid some easy cases of chdir by passing `git_root` instead of dynmically finding it based on cwd.