### PR TITLE
test: avoid changing os.environ

### DIFF
--- a/src/extensions/score_source_code_linker/tests/test_repo_source_link_integration.py
+++ b/src/extensions/score_source_code_linker/tests/test_repo_source_link_integration.py
@@ -45,12 +45,12 @@ from src.extensions.score_source_code_linker.repo_source_links import (
 """
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sphinx_base_dir(tmp_path_factory: TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("test_module_links_repo")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def git_repo_setup(sphinx_base_dir: Path) -> Path:
     """Creating git repo, to make testing possible"""
     repo_path = sphinx_base_dir
@@ -66,11 +66,10 @@ def git_repo_setup(sphinx_base_dir: Path) -> Path:
         cwd=repo_path,
         check=True,
     )
-    os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(repo_path)
     return repo_path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def create_demo_files(sphinx_base_dir: Path, git_repo_setup: Path):
     repo_path = sphinx_base_dir
 
@@ -249,11 +248,12 @@ def test_repo_grouped_cache_generated(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Happy path: Repo grouped cache file is generated after Sphinx build"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"
@@ -279,11 +279,12 @@ def test_repo_grouping_preserves_metadata(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Happy path: Repo metadata (name, hash, url) is preserved in cache"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"
@@ -306,11 +307,12 @@ def test_repo_grouping_multiple_needs_per_repo(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Happy path: Multiple needs from same repo are grouped together"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"
@@ -338,14 +340,15 @@ def test_repo_cache_json_format(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Repo cache JSON has correct
     structure and excludes metadata from links
     """
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"
@@ -389,11 +392,12 @@ def test_repo_cache_rebuilds_when_missing(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Edge case: Repo cache is regenerated if deleted"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"
@@ -423,11 +427,12 @@ def test_repo_grouping_with_golden_file(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Happy path: Generated repo cache matches expected golden file"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
 
         repo_cache = app.outdir / "score_repo_grouped_scl_cache.json"

--- a/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
+++ b/src/extensions/score_source_code_linker/tests/test_source_code_link_integration.py
@@ -41,12 +41,12 @@ from src.extensions.score_source_code_linker.tests.test_need_source_links import
 from src.helper_lib import find_ws_root
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sphinx_base_dir(tmp_path_factory: TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("test_git_repo")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def git_repo_setup(sphinx_base_dir: Path) -> Path:
     """Creating git repo, to make testing possible"""
 
@@ -64,11 +64,10 @@ def git_repo_setup(sphinx_base_dir: Path) -> Path:
         cwd=repo_path,
         check=True,
     )
-    os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(repo_path)
     return repo_path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def create_demo_files(sphinx_base_dir: Path, git_repo_setup: Path):
     repo_path = sphinx_base_dir
 
@@ -511,11 +510,12 @@ def test_source_link_integration_ok(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """This is a test description"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
-        os.environ["BUILD_WORKSPACE_DIRECTORY"] = str(sphinx_base_dir)
         app.build()
         ws_root = find_ws_root()
         assert ws_root is not None
@@ -574,8 +574,10 @@ def test_source_link_integration_non_existent_id(
     sphinx_base_dir: Path,
     git_repo_setup: Path,
     create_demo_files: None,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Asserting warning if need not found"""
+    monkeypatch.setenv("BUILD_WORKSPACE_DIRECTORY", str(sphinx_base_dir))
     app = sphinx_app_setup()
     try:
         app.build()

--- a/src/extensions/score_source_code_linker/tests/test_xml_parser.py
+++ b/src/extensions/score_source_code_linker/tests/test_xml_parser.py
@@ -467,41 +467,27 @@ def test_get_metadata_from_test_path_local():
     assert md["url"] == ""
 
 
-def test_get_metadata_from_test_path_combo_with_hash(tmp_path: Path):
+def test_get_metadata_from_test_path_combo_with_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """Combo builds with 'hash' in known_good.json populate metadata correctly."""
     json_file = tmp_path / "known_good.json"
     json_file.write_text(json.dumps(_KNOWN_GOOD_WITH_HASH))
-
-    old = os.environ.get("KNOWN_GOOD_JSON")
-    try:
-        os.environ["KNOWN_GOOD_JSON"] = str(json_file)
-        md = xml_parser.get_metadata_from_test_path(_COMBO_TEST_PATH)
-    finally:
-        if old is None:
-            os.environ.pop("KNOWN_GOOD_JSON", None)
-        else:
-            os.environ["KNOWN_GOOD_JSON"] = old
-
+    monkeypatch.setenv("KNOWN_GOOD_JSON", str(json_file))
+    md = xml_parser.get_metadata_from_test_path(_COMBO_TEST_PATH)
     assert md["repo_name"] == "score_docs_as_code"
     assert md["hash"] == "abc123hashvalue"
     assert md["url"] == "https://github.com/eclipse-score/docs-as-code"
 
 
-def test_get_metadata_from_test_path_combo_with_version(tmp_path: Path):
+def test_get_metadata_from_test_path_combo_with_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """Combo builds with 'version' in known_good.json populate metadata correctly."""
     json_file = tmp_path / "known_good.json"
     json_file.write_text(json.dumps(_KNOWN_GOOD_WITH_VERSION))
-
-    old = os.environ.get("KNOWN_GOOD_JSON")
-    try:
-        os.environ["KNOWN_GOOD_JSON"] = str(json_file)
-        md = xml_parser.get_metadata_from_test_path(_COMBO_TEST_PATH)
-    finally:
-        if old is None:
-            os.environ.pop("KNOWN_GOOD_JSON", None)
-        else:
-            os.environ["KNOWN_GOOD_JSON"] = old
-
+    monkeypatch.setenv("KNOWN_GOOD_JSON", str(json_file))
+    md = xml_parser.get_metadata_from_test_path(_COMBO_TEST_PATH)
     assert md["repo_name"] == "score_docs_as_code"
     assert md["hash"] == "v2.1.0"
     assert md["url"] == "https://github.com/eclipse-score/docs-as-code"

--- a/src/extensions/score_source_code_linker/tests/test_xml_parser.py
+++ b/src/extensions/score_source_code_linker/tests/test_xml_parser.py
@@ -22,7 +22,6 @@ Once we enable those we will need to change the tests
 """
 
 import json
-import os
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from pathlib import Path

--- a/src/helper_lib/test_helper_lib.py
+++ b/src/helper_lib/test_helper_lib.py
@@ -263,25 +263,24 @@ def test_get_current_git_hash_invalid_repo(temp_dir: Path):
         get_current_git_hash(temp_dir)
 
 
-def test_runfiles_dir_found(temp_dir: Path):
+def test_runfiles_dir_found(temp_dir: Path, monkeypatch: pytest.MonkeyPatch):
     """Test Runfiles dir found when provided and it's actually there"""
     runfiles_dir = temp_dir / "runfiles_here"
     runfiles_dir.mkdir(parents=True)
-    os.environ["RUNFILES_DIR"] = str(runfiles_dir)
-    os.chdir(runfiles_dir)
+    monkeypatch.setenv("RUNFILES_DIR", str(runfiles_dir))
+    # No chdir needed: get_runfiles_dir() reads the env var directly and never consults CWD.
     result = get_runfiles_dir()
     assert Path(result) == runfiles_dir
-    os.environ.pop("RUNFILES_DIR", None)
 
 
-def test_runfiles_dir_missing_triggers_exit(temp_dir: Path):
+def test_runfiles_dir_missing_triggers_exit(temp_dir: Path, monkeypatch: pytest.MonkeyPatch):
     """Testing if the runfiles exit via sys.exit if runfiles are set but don't exist"""
     runfiles_dir = temp_dir / "does_not_exist"
-    os.environ["RUNFILES_DIR"] = str(runfiles_dir)
+    monkeypatch.setenv("RUNFILES_DIR", str(runfiles_dir))
     with pytest.raises(SystemExit) as e:
+        # No chdir needed: get_runfiles_dir() reads the env var directly and never consults CWD.
         get_runfiles_dir()
     assert "Could not find runfiles_dir" in str(e.value)
-    os.environ.pop("RUNFILES_DIR", None)
 
 
 def test_git_root_search_success(git_repo: Path, monkeypatch: pytest.MonkeyPatch):

--- a/src/helper_lib/test_helper_lib.py
+++ b/src/helper_lib/test_helper_lib.py
@@ -273,7 +273,9 @@ def test_runfiles_dir_found(temp_dir: Path, monkeypatch: pytest.MonkeyPatch):
     assert Path(result) == runfiles_dir
 
 
-def test_runfiles_dir_missing_triggers_exit(temp_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_runfiles_dir_missing_triggers_exit(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
     """Testing if the runfiles exit via sys.exit if runfiles are set but don't exist"""
     runfiles_dir = temp_dir / "does_not_exist"
     monkeypatch.setenv("RUNFILES_DIR", str(runfiles_dir))


### PR DESCRIPTION
## Why

Tests that directly assign to `os.environ` and clean up manually are fragile: if a test raises before the cleanup code runs, the environment variable leaks into every subsequent test in the same process. Because several of these fixtures were scoped to `session`, a leaked `BUILD_WORKSPACE_DIRECTORY` or `KNOWN_GOOD_JSON` could silently influence unrelated tests, making failures order-dependent and hard to reproduce. The manual try/finally pattern for saving and restoring the old value is also noisy boilerplate that obscures the test's actual intent.

A subtler problem with `session`-scoped fixtures is that `monkeypatch` only supports `function` and `module` scope — you can't use it with `session`. The fix must therefore reduce the fixture scope to `module` before switching to `monkeypatch`.

## What

Replace all direct `os.environ` mutations in tests with `monkeypatch.setenv`. This is pytest's standard mechanism for environment isolation: it automatically reverts every change after the test (or module) finishes, even if the test raises. No manual save/restore or `os.environ.pop` calls are needed.

Fixtures in `test_repo_source_link_integration.py` and `test_source_code_link_integration.py` that were previously `session`-scoped are downgraded to `module`-scoped so that `monkeypatch` can be used safely. The `git_repo_setup` fixtures no longer set `BUILD_WORKSPACE_DIRECTORY` themselves; each test that needs it sets it via `monkeypatch.setenv` instead, keeping environment side-effects visible at the call site.

In `test_helper_lib.py`, the `os.chdir` call in `test_runfiles_dir_found` is also removed — it was unnecessary because `get_runfiles_dir()` reads the env var directly and never consults the working directory.

## Changes

- `test_repo_source_link_integration.py` — downgrade `sphinx_base_dir`, `git_repo_setup`, `create_demo_files` from `session` to `module` scope; remove `os.environ` assignment from `git_repo_setup`; replace six direct `os.environ["BUILD_WORKSPACE_DIRECTORY"] = …` assignments with `monkeypatch.setenv`
- `test_source_code_link_integration.py` — same scope downgrade; remove `os.environ` assignment from `git_repo_setup`; replace two direct assignments with `monkeypatch.setenv`
- `test_xml_parser.py` — replace two manual try/finally save-restore patterns around `KNOWN_GOOD_JSON` with `monkeypatch.setenv`
- `test_helper_lib.py` — replace manual `os.environ` mutation and `os.environ.pop` cleanup with `monkeypatch.setenv`; remove the unnecessary `os.chdir` call