### PR TITLE
fix: mark gd_req__doc_attr_status satisfied

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -304,15 +304,16 @@ Versioning
   :id: tool_req__docs_doc_generic_mandatory
   :tags: Documents
   :implemented: PARTIAL
-  :version: 1
+  :version: 2
   :satisfies:
    gd_req__doc_attributes_manual,
-   gd_req__change_attr_impact_safety
+   gd_req__change_attr_impact_safety,
+   gd_req__doc_attr_status,
   :parent_covered: YES
 
-  Docs-as-Code shall enforce that each Generic Document ``doc__*`` has the following attributes:
+  Enforce that each Generic Document ``doc__*`` has the following attributes:
 
-  * status
+  * status (one of: valid, draft, invalid)
   * security
   * safety
   * realizes

--- a/src/extensions/score_metamodel/tests/rst/options/test_options_options.rst
+++ b/src/extensions/score_metamodel/tests/rst/options/test_options_options.rst
@@ -233,6 +233,25 @@
    :safety: ASIL_B
 
 
+.. Tests if the attribute `status` follows the pattern `^(valid|draft|invalid)$`
+#EXPECT-NOT[+2]: does not follow pattern
+
+.. document:: This is a test document
+   :id: doc__test_good_3
+   :status: draft
+   :safety: QM
+
+
+#EXPECT[+4]: doc__test_bad_status_1.status (active): does not follow pattern `^(valid|draft|invalid)$`.
+#EXPECT[+3]: doc__test_bad_status_1: is missing required attribute: `security`.
+#EXPECT[+2]: doc__test_bad_status_1: is missing required link: `realizes`.
+
+.. document:: This is a test document
+   :id: doc__test_bad_status_1
+   :status: active
+   :safety: QM
+
+
 #EXPECT-NOT[+2]: does not follow pattern
 
 .. stkh_req:: This is a test


### PR DESCRIPTION
We already implemented it.
Now there is also two tests.

## 🚨 Impact Analysis

- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [ ] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines
