### PR TITLE
Use CI GitHub env vars for docs metadata

### DIFF
--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -55,6 +55,6 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      bazel-target: "--lockfile_mode=error //:docs -- --github_user=${{ github.repository_owner }} --github_repo=${{ github.event.repository.name }}"
+      bazel-target: "//:docs"
       retention-days: 3
       tests-report-artifact: tests-report

--- a/src/incremental.py
+++ b/src/incremental.py
@@ -80,15 +80,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--debug", help="Enable Debugging via debugpy", action="store_true"
     )
-    # optional GitHub user forwarded from the Bazel CLI
-    parser.add_argument(
-        "--github_user",
-        help="GitHub username to embed in the Sphinx build",
-    )
-    parser.add_argument(
-        "--github_repo",
-        help="GitHub repository to embed in the Sphinx build",
-    )
+    parser.add_argument("--github_user", help=argparse.SUPPRESS)
+    parser.add_argument("--github_repo", help=argparse.SUPPRESS)
     parser.add_argument(
         "--port",
         type=int,
@@ -140,10 +133,13 @@ if __name__ == "__main__":
         metamodel_yaml = os.path.abspath(metamodel_yaml)
         base_arguments.append(f"--define=score_metamodel_yaml={metamodel_yaml}")
 
-    # configure sphinx build with GitHub user and repo from CLI
-    if args.github_user and args.github_repo:
-        base_arguments.append(f"-A=github_user={args.github_user}")
-        base_arguments.append(f"-A=github_repo={args.github_repo}")
+    github_user = os.getenv("GITHUB_REPOSITORY_OWNER")
+    github_repo_env = os.getenv("GITHUB_REPOSITORY")
+    github_repo = github_repo_env.split("/")[1] if github_repo_env else None
+
+    if github_user and github_repo:
+        base_arguments.append(f"-A=github_user={github_user}")
+        base_arguments.append(f"-A=github_repo={github_repo}")
         base_arguments.append("-A=github_version=main")
         base_arguments.append(f"-A=doc_path={get_env('SOURCE_DIRECTORY')}")
     if os.getenv("KNOWN_GOOD_JSON"):

--- a/src/incremental.py
+++ b/src/incremental.py
@@ -133,15 +133,14 @@ if __name__ == "__main__":
         metamodel_yaml = os.path.abspath(metamodel_yaml)
         base_arguments.append(f"--define=score_metamodel_yaml={metamodel_yaml}")
 
-    github_user = os.getenv("GITHUB_REPOSITORY_OWNER")
-    github_repo_env = os.getenv("GITHUB_REPOSITORY")
-    github_repo = github_repo_env.split("/")[1] if github_repo_env else None
+    if github_repository := os.getenv("GITHUB_REPOSITORY"):
+        github_user, _, github_repo = github_repository.partition("/")
 
-    if github_user and github_repo:
         base_arguments.append(f"-A=github_user={github_user}")
         base_arguments.append(f"-A=github_repo={github_repo}")
         base_arguments.append("-A=github_version=main")
         base_arguments.append(f"-A=doc_path={get_env('SOURCE_DIRECTORY')}")
+
     if os.getenv("KNOWN_GOOD_JSON"):
         base_arguments.append(f"--define=KNOWN_GOOD_JSON={get_env('KNOWN_GOOD_JSON')}")
 

--- a/src/incremental.py
+++ b/src/incremental.py
@@ -134,6 +134,8 @@ if __name__ == "__main__":
         base_arguments.append(f"--define=score_metamodel_yaml={metamodel_yaml}")
 
     if github_repository := os.getenv("GITHUB_REPOSITORY"):
+        # GITHUB_REPOSITORY is expected as "owner/repo"; partition("/") splits
+        # once into (owner, separator, repo), so we can ignore the separator.
         github_user, _, github_repo = github_repository.partition("/")
 
         base_arguments.append(f"-A=github_user={github_user}")


### PR DESCRIPTION
## Why
The docs workflow currently forwards `github_user` and `github_repo` through the Bazel target string. This couples CI wiring to CLI-only arguments and makes the build invocation harder to maintain.

At the same time, these arguments are not meant for end users, but they still appear as regular CLI options in `src/incremental.py`.

## What
### Read GitHub metadata from standard CI environment variables
Use `GITHUB_REPOSITORY_OWNER` and `GITHUB_REPOSITORY` inside `src/incremental.py` to derive the owner and repository for Sphinx metadata.

### Keep CLI compatibility while hiding internal flags
Keep parsing `--github_user` and `--github_repo`, but suppress them from help output so they remain internal/compatibility inputs instead of documented user options.

### Simplify workflow Bazel invocation
Update the workflow to call `//:docs` directly instead of embedding forwarded GitHub values in `bazel-target`.

## Changes
- `.github/workflows/test_and_docs.yml`: remove forwarded GitHub values from `bazel-target` and use `//:docs`.
- `src/incremental.py`: suppress help for internal GitHub CLI args and source Sphinx GitHub metadata from CI environment variables.
