### PR TITLE
feat: new attribute doc_tool.tool_version

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -919,12 +919,12 @@ Testing
   :id: tool_req__docs_tvr_version
   :tags: Tool Verification Reports
   :implemented: YES
-  :version: 1
+  :version: 2
   :satisfies: gd_req__tool_attr_version
   :parent_covered: YES
 
   Docs-as-Code shall enforce that every Tool Verification Report (`doc_tool`) includes a
-  `version` attribute.
+  `tool_version` attribute.
 
 .. tool_req:: Enforce confidence level classification
   :id: tool_req__docs_tvr_confidence_level

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -227,8 +227,6 @@ needs_types:
     mandatory_options:
       # req-Id: tool_req__docs_tvr_status
       status: ^(draft|evaluated|qualified|released|rejected)$
-      # req-Id: tool_req__docs_tvr_version
-      version: ^.*$
       # req-Id: tool_req__docs_tvr_safety
       safety_affected: "^(YES|NO)$"
       # req-Id: tool_req__docs_tvr_security
@@ -240,6 +238,9 @@ needs_types:
       author: ^.*$
       approver: ^.*$
       reviewer: ^.*$
+      # FIXME: temp optional for migration. Will be made mandatory in future releases.
+      # req-Id: tool_req__docs_tvr_version
+      tool_version: ^.*$
     optional_links:
       realizes: workproduct
     parts: 2

--- a/src/extensions/score_metamodel/yaml_parser.py
+++ b/src/extensions/score_metamodel/yaml_parser.py
@@ -123,10 +123,6 @@ def _parse_need_type(
     errors: list[str] = []
     for a_name, a, b_name, b in overlap_checks:
         if overlap := set(a.keys()) & set(b.keys()):
-            # FIXME: remove once "version" is clarified with process team
-            if overlap == {"version"}:
-                continue
-
             errors.append(
                 f"Directive '{directive_name}': {a_name} and {b_name} overlap: {overlap}."
             )


### PR DESCRIPTION
Optional for now, as process still has examples. And those don't have tool_version - they cant have it, without this PR.

This implements https://github.com/eclipse-score/process_description/pull/701