### PR TITLE
chore(deps): bump process to 1.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,12 +69,6 @@ http_file(
     urls = ["https://github.com/withered-magic/starpls/releases/download/v0.1.21/starpls-linux-amd64"],
 )
 
-bazel_dep(name = "score_process", version = "1.5.4")
-git_override(
-    module_name = "score_process",
-    commit = "0113471d1dbb58d0890dae2569b18af69cd2025f",
-    remote = "https://github.com/eclipse-score/process_description.git",
-)
-
+bazel_dep(name = "score_process", version = "1.6.0")
 # Provide the tools from the devcontainer to Bazel
 bazel_dep(name = "score_devcontainer", version = "1.7.0")


### PR DESCRIPTION
no lockfile update, as process 1.6.0 is not released yet

"1.6.0" confirmed in process meeting.

Plan:
* merge this PR
* create docs as code 4.5.0
* publish to registry
* update dependency in process to 4.5.0
* create process 1.6.0
* publish to registry