### PR TITLE
docs: render traceability on a page

### DIFF
--- a/docs/internals/requirements/index.rst
+++ b/docs/internals/requirements/index.rst
@@ -30,6 +30,8 @@ Pages
 
 - ``tooling_verification`` describes verification evidence for the tooling
   itself, including test results and testcase metadata.
+- ``requirement_coverage`` shows per-requirement test and code linkage,
+  using the same metrics as CI quality gates.
 
 .. toctree::
    :maxdepth: 1
@@ -37,4 +39,5 @@ Pages
    capabilities
    process_overview
    requirements
+   requirement_coverage
    tooling_verification

--- a/docs/internals/requirements/requirement_coverage.rst
+++ b/docs/internals/requirements/requirement_coverage.rst
@@ -31,7 +31,7 @@ Overall Coverage
    :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(overall_metrics:total,overall_metrics:with_test_link,overall_metrics:with_code_link,overall_metrics:fully_linked)
 
 .. needpie:: Test Linkages
-   :labels: Tests Linked, Tests Not Linked
+   :labels: Tests Not Linked, Tests Linked
    :colors: #59A14F, #4E79A7
    :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(tests:total,tests:linked_to_requirements)
 

--- a/docs/internals/requirements/requirement_coverage.rst
+++ b/docs/internals/requirements/requirement_coverage.rst
@@ -27,12 +27,12 @@ Overall Coverage
 
 .. needpie:: Overall Requirement Coverage
    :labels: Remaining (no selected links), With Test Link, With Code Link, Fully Linked
-   :colors: #4E79A7, #F28E2B, #59A14F, #B07AA1
+   :colors: #ca2828, #009ad2, #d26403, #37a12d
    :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(overall_metrics:total,overall_metrics:with_test_link,overall_metrics:with_code_link,overall_metrics:fully_linked)
 
 .. needpie:: Test Linkages
    :labels: Tests Not Linked, Tests Linked
-   :colors: #59A14F, #4E79A7
+   :colors: #ca2828, #37a12d
    :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(tests:total,tests:linked_to_requirements)
 
 Requirement → Test Traceability

--- a/docs/internals/requirements/requirement_coverage.rst
+++ b/docs/internals/requirements/requirement_coverage.rst
@@ -1,0 +1,53 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+.. _docs_requirement_coverage:
+
+Requirement Test Coverage
+=========================
+
+This page shows which requirements are linked to tests and which have code
+links.
+The numbers shown here come from the same ``score_metrics`` calculations used
+by CI quality gates — they will always match.
+
+Overall Coverage
+----------------
+
+.. needpie:: Overall Requirement Coverage
+   :labels: Remaining (no selected links), With Test Link, With Code Link, Fully Linked
+   :colors: #4E79A7, #F28E2B, #59A14F, #B07AA1
+   :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(overall_metrics:total,overall_metrics:with_test_link,overall_metrics:with_code_link,overall_metrics:fully_linked)
+
+.. needpie:: Test Linkages
+   :labels: Tests Linked, Tests Not Linked
+   :colors: #59A14F, #4E79A7
+   :filter-func: score_metrics.sphinx_filters.get_metrics_with_first_value_total(tests:total,tests:linked_to_requirements)
+
+Requirement → Test Traceability
+-------------------------------
+
+.. needtable:: All tool_req with Linkage Status
+   :types: tool_req
+   :columns: id;testlink;source_code_link;implemented
+   :style: table
+
+Test → Requirement Traceability
+-------------------------------
+
+.. needtable:: All Testcases with Covered Requirements
+   :types: testcase
+   :filter: result == "passed"
+   :columns: name as "Testcase";fully_verifies;partially_verifies;test_type;derivation_technique
+   :style: table


### PR DESCRIPTION
See https://eclipse-score.github.io/docs-as-code/pr-608/internals/requirements/requirement_coverage.html