### PR TITLE
Link rst tests to reqs

### DIFF
--- a/src/extensions/score_metamodel/tests/rst/architecture/architecture_tests.rst
+++ b/src/extensions/score_metamodel/tests/rst/architecture/architecture_tests.rst
@@ -14,6 +14,10 @@
 
 #CHECK: check_options
 
+#PARTIALLY-VERIFIES: tool_req__docs_arch_types
+#PARTIALLY-VERIFIES: tool_req__docs_arch_attr_mandatory
+#PARTIALLY-VERIFIES: tool_req__docs_arch_link_fulfils
+
 .. stkh_req:: Test Stakeholder Requirement 1
    :id: stkh_req__test_stakeholder_requirement_1__basic_stkh_req
    :reqtype: Non-Functional

--- a/src/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_format.rst
+++ b/src/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_format.rst
@@ -13,6 +13,8 @@
    # *******************************************************************************
 #CHECK: check_id_format
 
+#PARTIALLY-VERIFIES: tool_req__docs_common_attr_id_scheme
+
 .. Id does not consists of 3 parts
 #EXPECT[+2]: stkh_req__test.id (stkh_req__test): expected to consist of this format: `<Req Type>__<Abbreviations>__<Architectural Element>`.
 

--- a/src/extensions/score_metamodel/tests/test_rules_file_based.py
+++ b/src/extensions/score_metamodel/tests/test_rules_file_based.py
@@ -113,6 +113,8 @@ class RstData:
     warning_infos: list[WarningInfo] = field(default_factory=list)
     found_objects: list[int] = field(default_factory=list)
     syntax_errors: list[str] = field(default_factory=list)
+    partially_verifies: list[str] = field(default_factory=list)
+    fully_verifies: list[str] = field(default_factory=list)
 
 
 def parse_line_for_message(line: str) -> str:
@@ -179,6 +181,17 @@ def extract_test_data(rst_file: Path) -> tuple[RstData, list[ErrorChecks]]:
             if line.startswith("#CHECK:"):
                 assert not rst_data.enabled_checks, "only one CHECK per file allowed"
                 rst_data.enabled_checks = parse_line_for_message(line)
+
+            # Requirement references for traceability
+            if line.startswith("#PARTIALLY-VERIFIES:"):
+                ids_str = parse_line_for_message(line)
+                rst_data.partially_verifies = [
+                    rid.strip() for rid in ids_str.split(",")
+                ]
+
+            if line.startswith("#FULLY-VERIFIES:"):
+                ids_str = parse_line_for_message(line)
+                rst_data.fully_verifies = [rid.strip() for rid in ids_str.split(",")]
 
     return rst_data, parsed_checks
 
@@ -257,12 +270,30 @@ def test_rst_files(
     rst_file: str,
     sphinx_app_setup: Callable[[Path], SphinxTestApp],
     monkeypatch: pytest.MonkeyPatch,
+    record_property: Callable[[str, str], None],
+    record_xml_attribute: Callable[[str, str], None],
 ) -> None:
     ### Test function to check rules in the given rst file
     # The function uses the SphinxTestApp to build the documentation
     # and checks for the expected/unexpected warnings.
     rst_data_raw, parsed_checks_raw = extract_test_data(RST_DIR / rst_file)
     rst_data = group_test_data(rst_data_raw, parsed_checks_raw)
+
+    # Point the XML testcase file/line to the actual .rst file under test,
+    # so traceability links reference the specification, not the test harness.
+    rst_rel_path = f"src/extensions/score_metamodel/tests/rst/{rst_file}"
+    record_xml_attribute("file", rst_rel_path)
+    record_xml_attribute("line", "1")
+
+    # Attach requirement references as pytest properties for traceability.
+    # These appear in JUnit XML output and are picked up by score_source_code_linker.
+    if rst_data.partially_verifies:
+        record_property("PartiallyVerifies", ", ".join(rst_data.partially_verifies))
+    if rst_data.fully_verifies:
+        record_property("FullyVerifies", ", ".join(rst_data.fully_verifies))
+    # Always set these for consistency with other test frameworks.
+    record_property("TestType", "requirements-based")
+    record_property("DerivationTechnique", "requirements-analysis")
 
     # ╓                                                          ╖
     # ║ Will be activated once 'architecture_check.rst' is fixed ║


### PR DESCRIPTION
Docs-as-code has many requirements about the metamodel but they have no testlinks yet because our rst-tests were not able to specify a link. This PR adds this functionality and adds a few example links.