### PR TITLE
WIP: sphinx-needs filtering, Markdown & TRLC export rules (demo playground)

### DIFF
--- a/CHANGES_trlc_to_sphinx_needs_summary.txt
+++ b/CHANGES_trlc_to_sphinx_needs_summary.txt
@@ -1,0 +1,89 @@
+Zusammenfassung der Änderungen: trlc_to_sphinx_needs – Vererbung & Links
+==========================================================================
+
+Datum: 2026-07-01
+Branches:
+  - docs-as-code: ankr_rules_score_playground
+  - baselibs:     ankr_score_rules_wip
+
+Ziel
+----
+Der TRLC->sphinx-needs-Konverter soll Vererbung/Links (`derived_from`)
+respektieren und die referenzierten Requirements (z.B. Feature Requirements)
+mit in die generierte needs.json aufnehmen, damit die Links auflösen.
+
+
+1) Konverter: scripts_bazel/trlc_to_sphinx_needs.py (docs-as-code)
+------------------------------------------------------------------
+- `derived_from` wird jetzt als echter sphinx-needs-Link mit Versions-
+  constraint gerendert:
+    TRLC   `SampleSEooC.FEAT_001@1`
+    -> Need `FEAT_001[version==1]`
+  (Paketpräfix `SampleSEooC.` entfernt, `@<version>` -> `[version==N]`).
+  Das entspricht exakt dem Speicherformat von sphinx-needs (an echter
+  needs.json verifiziert, z.B. `satisfies=['wf__cr_mt_featarch[version==1]']`).
+- Parser bewahrt den `@version`-Suffix in Referenzlisten (vorher verworfen).
+- Neue Typ-Zuordnung `AssumedSystemReq -> stkh_req` (Stakeholder Requirement)
+  inkl. Ausgabe des Pflichtfeldes `rationale`.
+- `convert()` / `main()` akzeptieren jetzt mehrere `.trlc`-Eingabedateien
+  (nargs="+"), damit paketübergreifend referenzierte Requirements in
+  derselben needs.json landen und die Links auflösen.
+- Neue Hilfsfunktion `_link_ref()` für die Referenz-/Versionsumwandlung.
+
+
+2) Bazel-Regel: docs.bzl (docs-as-code)
+---------------------------------------
+- `trlc_to_sphinx_needs` nimmt jetzt `srcs` (Liste) statt `src` (Einzeldatei)
+  und übergibt alle Dateien via `$(SRCS)` an das Tool.
+- Docstring entsprechend erweitert (neuer Typ, Link-/Versionsverhalten,
+  Hinweis auf das Mitliefern referenzierter Requirements).
+
+
+3) baselibs
+-----------
+- Referenzierte Requirement-Dateien aus dem tooling-Beispiel kopiert:
+    - feature_requirements.trlc        (package SampleSEooC, FeatReq)
+    - assumed_system_requirements.trlc (package SampleSEooC, AssumedSystemReq)
+  (component_requirements.trlc existierte bereits.)
+- BUILD: Ziel `baselibs_aous_from_trlc` verweist nun auf alle drei TRLC-Dateien
+  über `srcs = [component_requirements.trlc, feature_requirements.trlc,
+  assumed_system_requirements.trlc]`.
+
+
+Metamodell-Hintergrund (score_metamodel)
+----------------------------------------
+- comp_req.derived_from -> feat_req   (optional link)
+- feat_req.derived_from -> stkh_req   (optional link)
+- Link-Werte werden in needs.json inkl. Versionsconstraint gespeichert:
+  z.B. `"derived_from": ["FEAT_001[version==1]"]`.
+- Pflichtfelder stkh_req: reqtype, safety (QM|ASIL_B), status, rationale,
+  security.
+
+
+Verifikation
+------------
+Befehl:
+  cd /workspaces/baselibs && bazel build //:baselibs_aous_from_trlc
+
+Ergebnis: "Converted 3 file(s) -> ... (11 requirements, project 'Baselibs')"
+  - 2x stkh_req (ASR_SAMPLE_001/002, mit rationale)
+  - 4x feat_req (FEAT_001..004, derived_from -> ASR_SAMPLE_00x[version==1])
+  - 5x comp_req (REQ_COMP_001..005, derived_from -> FEAT_00x[version==1])
+    - REQ_COMP_004 mit zwei Links: FEAT_003[version==1], FEAT_004[version==1]
+Aufgelöste Kette: comp_req -> feat_req -> stkh_req.
+
+
+Noch offen / nicht committet
+----------------------------
+- Diese Änderungen sind noch NICHT committet (auf Wunsch).
+- Frühere Commits in dieser Session (bereits erledigt):
+    - docs-as-code: a6eca138 (feat_arch/comp_reqs/comp_arch Sub-Targets +
+      trlc_to_sphinx_needs Regel/Skript)
+    - baselibs:     2afce64  (component_requirements.trlc + BUILD-Verdrahtung)
+- Betroffene, noch uncommittete Dateien:
+    - docs-as-code/docs.bzl
+    - docs-as-code/scripts_bazel/trlc_to_sphinx_needs.py
+    - baselibs/BUILD
+    - baselibs/feature_requirements.trlc (neu)
+    - baselibs/assumed_system_requirements.trlc (neu)
+</content>

--- a/How-to: S-Core process step-by-step.md
+++ b/How-to: S-Core process step-by-step.md
@@ -1,0 +1,13 @@
+# How-to: S-Core process step-by-step
+
+## 1. Feature & Feature requirements in main score repository
+
+### a. What to do
+
+1. Define Feature
+2. Define Feature Requirements and map them to the stakeholder requirements
+
+### b. How to check
+
+1. Automated checks for requirements in docs-as-code.
+2. Checklist for things, that can not be automated -> automated check, that checklist is up to date.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,29 @@ pre-commit install --hook-type pre-push
 ```
 
 Execute the pre-commit manually via `pre-commit run` or `pre-commit run --all-files` to run it on all files.
+
+## Sphinx-needs processing rules
+
+> [!WARNING]
+> These rules are currently a **work-in-progress / demonstration** and are not yet production ready.
+
+In addition to building the documentation, docs-as-code ships a set of Bazel macros
+(in [docs.bzl](docs.bzl), backed by the Python tools in [scripts_bazel/](scripts_bazel))
+that post-process the `needs.json` produced by the documentation build. They let you:
+
+- **Filter** `needs.json` down to selected element types and/or components
+  (`filtered_needs_json`, plus convenience wrappers such as `component_requirements`,
+  `feature_requirements`, `assumptions_of_use`, `feature_architecture`, `component_architecture`).
+- **Render** the selected needs as a Markdown document (`sphinx_needs_to_md`).
+- **Convert** S-CORE requirements into [TRLC](https://github.com/bmw-software-engineering/trlc)
+  (`sphinx_needs_to_trlc`).
+- **Validate checklists** by pinning a SHA256 hash on a `mod_insp` / `mod_ver_report`
+  record and failing the build when the reviewed output drifts
+  (`requirements_checklist`, `architecture_checklist`, `dfa_checklist`,
+  `fmea_checklist`, `verification_report`).
+- **Bundle** a component's or feature's checklists, docs and sub-components
+  (`score_component`, `score_module`).
+
+See [scripts_bazel/README_needs_rules.md](scripts_bazel/README_needs_rules.md) for the
+full guide, including usage examples, transitive-dependency hashing and resolving
+external needs via `extra_needs`.

--- a/docs.bzl
+++ b/docs.bzl
@@ -575,6 +575,160 @@ def architecture_checklist(
         visibility = visibility,
     )
 
+def score_component(
+        name,
+        component = None,
+        req_insp_id = None,
+        arc_insp_id = None,
+        src = "//:needs_json",
+        extra_needs = [],
+        visibility = None):
+    """Bundle the requirement and architecture checklists of a single component.
+
+    Creates the component requirement/architecture extraction targets plus their
+    inspection-record checklists and aggregates the two checklists into a single
+    target `name`. Building `name` builds both the component requirements
+    checklist and the component architecture checklist, so the build fails when
+    either drifts from its reviewed inspection record.
+
+    The following targets are generated:
+
+    * `<name>_comp_reqs`      - extracted component requirements
+    * `<name>_req_checklist`  - requirements inspection-record checklist
+    * `<name>_comp_arch`      - extracted component architecture
+    * `<name>_arch_checklist` - architecture inspection-record checklist
+    * `<name>`                - filegroup bundling both checklists
+
+    Args:
+        name: Name of the aggregate target and prefix for the generated targets.
+        component: Component name used to filter needs. Defaults to `name`.
+        req_insp_id: Id of the `mod_insp` record for the component requirements.
+            Defaults to `mod_insp__<component>__comp_req`.
+        arc_insp_id: Id of the `mod_insp` record for the component architecture.
+            Defaults to `mod_insp__<component>__comp_arc`.
+        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
+        extra_needs: Additional `needs_json` build outputs forwarded to both
+            checklists (e.g. `["@score_platform//:needs_json"]`).
+        visibility: Standard Bazel visibility for the generated targets.
+    """
+    component = component or name
+    req_insp_id = req_insp_id or "mod_insp__{}__comp_req".format(component)
+    arc_insp_id = arc_insp_id or "mod_insp__{}__comp_arc".format(component)
+
+    component_requirements(
+        name = name + "_comp_reqs",
+        src = src,
+        component = component,
+        visibility = visibility,
+    )
+    requirements_checklist(
+        name = name + "_req_checklist",
+        mod_insp_id = req_insp_id,
+        deps = [":" + name + "_comp_reqs"],
+        extra_needs = extra_needs,
+        visibility = visibility,
+    )
+    component_architecture(
+        name = name + "_comp_arch",
+        src = src,
+        component = component,
+        visibility = visibility,
+    )
+    architecture_checklist(
+        name = name + "_arch_checklist",
+        mod_insp_id = arc_insp_id,
+        deps = [":" + name + "_comp_arch"],
+        extra_needs = extra_needs,
+        visibility = visibility,
+    )
+    native.filegroup(
+        name = name,
+        srcs = [
+            ":" + name + "_req_checklist",
+            ":" + name + "_arch_checklist",
+        ],
+        visibility = visibility,
+    )
+
+def score_module(
+        name,
+        feature = None,
+        components = [],
+        req_insp_id = None,
+        arc_insp_id = None,
+        src = "//:needs_json",
+        extra_needs = [],
+        visibility = None):
+    """Bundle the feature checklists of a module with all of its components.
+
+    Creates the feature requirement/architecture extraction targets plus their
+    inspection-record checklists and aggregates them with every component listed
+    in `components` into a single target `name`. Building `name` builds the
+    feature requirements checklist, the feature architecture checklist and all
+    referenced component targets, so the build fails when any of them drifts from
+    its reviewed inspection record.
+
+    The following targets are generated:
+
+    * `<name>_feature_reqs`   - extracted feature requirements
+    * `<name>_req_checklist`  - feature requirements inspection-record checklist
+    * `<name>_feature_arch`   - extracted feature architecture
+    * `<name>_arch_checklist` - feature architecture inspection-record checklist
+    * `<name>`                - filegroup bundling both checklists and components
+
+    Args:
+        name: Name of the aggregate target and prefix for the generated targets.
+        feature: Feature name used to filter needs. Defaults to `name`.
+        components: Labels of `score_component` targets making up this module.
+            All of them are built together with the module checklists.
+        req_insp_id: Id of the `mod_insp` record for the feature requirements.
+            Defaults to `mod_insp__<feature>__feat_req`.
+        arc_insp_id: Id of the `mod_insp` record for the feature architecture.
+            Defaults to `mod_insp__<feature>__feat_arc`.
+        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
+        extra_needs: Additional `needs_json` build outputs forwarded to both
+            checklists (e.g. `["@score_platform//:needs_json"]`).
+        visibility: Standard Bazel visibility for the generated targets.
+    """
+    feature = feature or name
+    req_insp_id = req_insp_id or "mod_insp__{}__feat_req".format(feature)
+    arc_insp_id = arc_insp_id or "mod_insp__{}__feat_arc".format(feature)
+
+    feature_requirements(
+        name = name + "_feature_reqs",
+        src = src,
+        feature = feature,
+        visibility = visibility,
+    )
+    requirements_checklist(
+        name = name + "_req_checklist",
+        mod_insp_id = req_insp_id,
+        deps = [":" + name + "_feature_reqs"],
+        extra_needs = extra_needs,
+        visibility = visibility,
+    )
+    feature_architecture(
+        name = name + "_feature_arch",
+        src = src,
+        feature = feature,
+        visibility = visibility,
+    )
+    architecture_checklist(
+        name = name + "_arch_checklist",
+        mod_insp_id = arc_insp_id,
+        deps = [":" + name + "_feature_arch"],
+        extra_needs = extra_needs,
+        visibility = visibility,
+    )
+    native.filegroup(
+        name = name,
+        srcs = [
+            ":" + name + "_req_checklist",
+            ":" + name + "_arch_checklist",
+        ] + components,
+        visibility = visibility,
+    )
+
 def _missing_requirements(deps):
     """Add Python hub dependencies if they are missing."""
     found = []

--- a/docs.bzl
+++ b/docs.bzl
@@ -234,6 +234,66 @@ def assumptions_of_use(
         visibility = visibility,
     )
 
+def feature_architecture(
+        name,
+        src = "//:needs_json",
+        feature = None,
+        visibility = None):
+    """Extract the feature architecture from a needs.json file.
+
+    Convenience wrapper around `filtered_needs_json`. Produces a `<name>.json`
+    file containing the feature architecture elements. Static (`feat_arc_sta`)
+    and dynamic (`feat_arc_dyn`) architecture are not differentiated; both are
+    kept.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output. Defaults to the calling
+            package's `//:needs_json`.
+        feature: Optional feature name. If given, only feature architecture
+            elements tagged with that feature are kept; if omitted, all feature
+            architecture elements are kept.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filtered_needs_json(
+        name = name,
+        src = src,
+        types = ["feat_arc_sta", "feat_arc_dyn"],
+        components = [feature] if feature else [],
+        component_attr = "tags",
+        visibility = visibility,
+    )
+
+def component_architecture(
+        name,
+        src = "//:needs_json",
+        component = None,
+        visibility = None):
+    """Extract the component architecture from a needs.json file.
+
+    Convenience wrapper around `filtered_needs_json`. Produces a `<name>.json`
+    file containing the component architecture elements. Static (`comp_arc_sta`)
+    and dynamic (`comp_arc_dyn`) architecture are not differentiated; both are
+    kept.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output. Defaults to the calling
+            package's `//:needs_json`.
+        component: Optional component name. If given, only component architecture
+            elements tagged with that component are kept; if omitted, all
+            component architecture elements are kept.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filtered_needs_json(
+        name = name,
+        src = src,
+        types = ["comp_arc_sta", "comp_arc_dyn"],
+        components = [component] if component else [],
+        component_attr = "tags",
+        visibility = visibility,
+    )
+
 def sphinx_needs_to_md(
         name,
         src,
@@ -360,6 +420,74 @@ def requirements_checklist(
             (e.g. `"req_chklst__bitmanipulation__comp_req"`).
         deps: List of labels whose outputs are hashed and validated. Usually a
             single `component_requirements`/`filtered_needs_json` target.
+        src: Label of a `needs_json` build output containing the checklist need.
+            Defaults to the calling package's `//:needs_json`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    validate_tool = Label("//scripts_bazel:validate_checklist")
+
+    dep_args = " ".join(["$(locations %s)" % d for d in deps])
+
+    native.genrule(
+        name = name,
+        srcs = [src] + deps,
+        outs = [name + ".sha256"],
+        cmd = """
+        $(location {validate_tool}) \
+            --needs-json $(location {src})/needs.json \
+            --checklist-id '{checklist_id}' \
+            --output $@ \
+            {dep_args}
+        """.format(
+            validate_tool = validate_tool,
+            checklist_id = checklist_id,
+            src = src,
+            dep_args = dep_args,
+        ),
+        tools = [validate_tool],
+        visibility = visibility,
+    )
+
+def architecture_checklist(
+        name,
+        checklist_id,
+        deps,
+        src = "//:needs_json",
+        visibility = None):
+    """Validate an architecture checklist (`arch_chklst`) against its build output.
+
+    Building this target recomputes the SHA256 over the concatenated outputs of
+    `deps` and compares it to the `sha256` attribute of the `arch_chklst` need
+    `checklist_id` (looked up in `src`'s `needs.json`). The build **fails** when
+    the hashes differ, i.e. when a validated target output has changed since the
+    checklist was last reviewed.
+
+    Typical usage validates the extracted architecture of a component against the
+    checklist that reviewed it:
+
+        component_architecture(
+            name = "bitmanipulation_comp_arch",
+            component = "bitmanipulation",
+        )
+
+        architecture_checklist(
+            name = "bitmanipulation_arch_checklist",
+            checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+            deps = [":bitmanipulation_comp_arch"],
+        )
+
+    Run with `bazel build //:bitmanipulation_arch_checklist`. On the first run (or
+    after the architecture changes) the build fails and prints the actual SHA256;
+    copy it into the `sha256` attribute of the checklist need once the checklist
+    has been (re-)reviewed.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.sha256`.
+        checklist_id: Id of the `arch_chklst` need to validate
+            (e.g. `"arch_chklst__bitmanipulation__comp_arc"`).
+        deps: List of labels whose outputs are hashed and validated. Usually a
+            single `feature_architecture`/`component_architecture`/
+            `filtered_needs_json` target.
         src: Label of a `needs_json` build output containing the checklist need.
             Defaults to the calling package's `//:needs_json`.
         visibility: Standard Bazel visibility for the generated target.

--- a/docs.bzl
+++ b/docs.bzl
@@ -378,20 +378,20 @@ def sphinx_needs_to_trlc(
 
 def requirements_checklist(
         name,
-        checklist_id,
         deps,
+        mod_insp_id,
         src = "//:needs_json",
         link_fields = ["derived_from", "satisfies", "covers"],
         extra_needs = [],
         visibility = None):
-    """Validate a requirement checklist (`req_chklst`) against its build output.
+    """Validate a requirement inspection record against its build output.
 
     Building this target recomputes the SHA256 over the requirements in `deps`
     **and**, by default, over everything they depend on transitively, and
-    compares it to the `sha256` attribute of the `req_chklst` need `checklist_id`
-    (looked up in `src`'s `needs.json`). The build **fails** when the hashes
-    differ, i.e. when a validated requirement *or one of its (recursive)
-    dependencies* has changed since the checklist was last reviewed.
+    compares it to the `sha256` attribute of the `mod_insp` inspection record
+    `mod_insp_id` (looked up in `src`'s `needs.json`). The build **fails** when
+    the hashes differ, i.e. when a validated requirement *or one of its
+    (recursive) dependencies* has changed since the inspection was last reviewed.
 
     The dependency graph is the sphinx-needs link graph: starting from the
     requirements in `deps` (the *roots*), the `link_fields` (by default
@@ -403,7 +403,7 @@ def requirements_checklist(
     the requirements in `deps`.
 
     Typical usage validates the extracted requirements of a component against the
-    checklist that reviewed them:
+    inspection record that reviewed them:
 
         component_requirements(
             name = "bitmanipulation_comp_reqs",
@@ -412,24 +412,24 @@ def requirements_checklist(
 
         requirements_checklist(
             name = "bitmanipulation_req_checklist",
-            checklist_id = "req_chklst__bitmanipulation__comp_req",
+            mod_insp_id = "mod_insp__bitmanipulation__comp_req",
             deps = [":bitmanipulation_comp_reqs"],
         )
 
     Run with `bazel build //:bitmanipulation_req_checklist`. On the first run (or
     after the requirements change) the build fails and prints the actual SHA256;
-    copy it into the `sha256` attribute of the checklist need once the checklist
-    has been (re-)reviewed.
+    copy it into the `sha256` attribute of the inspection record once it has
+    been (re-)reviewed.
 
     Args:
         name: Name of the generated target. The output file is `<name>.sha256`.
-        checklist_id: Id of the `req_chklst` need to validate
-            (e.g. `"req_chklst__bitmanipulation__comp_req"`).
         deps: List of labels whose outputs define the root requirements that are
             hashed and validated. Usually a single
             `component_requirements`/`feature_requirements`/`filtered_needs_json`
             target.
-        src: Label of a `needs_json` build output containing the checklist need
+        mod_insp_id: Id of the `mod_insp` inspection record to validate
+            (e.g. `"mod_insp__bitmanipulation__comp_req"`).
+        src: Label of a `needs_json` build output containing the inspection record
             and the full link graph. Defaults to the calling package's
             `//:needs_json`.
         link_fields: Sphinx-needs link fields followed recursively from the root
@@ -458,14 +458,14 @@ def requirements_checklist(
         cmd = """
         $(location {validate_tool}) \
             --needs-json $(location {src})/needs.json \
-            --checklist-id '{checklist_id}' \
+            --checklist-id '{mod_insp_id}' \
             --output $@ \
             {link_args} \
             {extra_args} \
             {dep_args}
         """.format(
             validate_tool = validate_tool,
-            checklist_id = checklist_id,
+            mod_insp_id = mod_insp_id,
             src = src,
             link_args = link_args,
             extra_args = extra_args,
@@ -477,20 +477,20 @@ def requirements_checklist(
 
 def architecture_checklist(
         name,
-        checklist_id,
         deps,
+        mod_insp_id,
         src = "//:needs_json",
         link_fields = ["fulfils", "includes", "uses", "provides", "derived_from", "satisfies", "covers"],
         extra_needs = [],
         visibility = None):
-    """Validate an architecture checklist (`arch_chklst`) against its build output.
+    """Validate an architecture inspection record against its build output.
 
     Building this target recomputes the SHA256 over the architecture in `deps`
     **and**, by default, over everything they depend on transitively, and
-    compares it to the `sha256` attribute of the `arch_chklst` need `checklist_id`
-    (looked up in `src`'s `needs.json`). The build **fails** when the hashes
-    differ, i.e. when a validated architecture element *or one of its (recursive)
-    dependencies* has changed since the checklist was last reviewed.
+    compares it to the `sha256` attribute of the `mod_insp` inspection record
+    `mod_insp_id` (looked up in `src`'s `needs.json`). The build **fails** when
+    the hashes differ, i.e. when a validated architecture element *or one of its
+    (recursive) dependencies* has changed since the inspection was last reviewed.
 
     The dependency graph is the sphinx-needs link graph: starting from the
     architecture elements in `deps` (the *roots*), the `link_fields` are followed
@@ -503,7 +503,7 @@ def architecture_checklist(
     behaviour of hashing only the elements in `deps`.
 
     Typical usage validates the extracted architecture of a component against the
-    checklist that reviewed it:
+    inspection record that reviewed it:
 
         component_architecture(
             name = "bitmanipulation_comp_arch",
@@ -512,24 +512,24 @@ def architecture_checklist(
 
         architecture_checklist(
             name = "bitmanipulation_arch_checklist",
-            checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+            mod_insp_id = "mod_insp__bitmanipulation__comp_arc",
             deps = [":bitmanipulation_comp_arch"],
         )
 
     Run with `bazel build //:bitmanipulation_arch_checklist`. On the first run (or
     after the architecture changes) the build fails and prints the actual SHA256;
-    copy it into the `sha256` attribute of the checklist need once the checklist
-    has been (re-)reviewed.
+    copy it into the `sha256` attribute of the inspection record once it has
+    been (re-)reviewed.
 
     Args:
         name: Name of the generated target. The output file is `<name>.sha256`.
-        checklist_id: Id of the `arch_chklst` need to validate
-            (e.g. `"arch_chklst__bitmanipulation__comp_arc"`).
         deps: List of labels whose outputs define the root architecture elements
             that are hashed and validated. Usually a single
             `feature_architecture`/`component_architecture`/`filtered_needs_json`
             target.
-        src: Label of a `needs_json` build output containing the checklist need
+        mod_insp_id: Id of the `mod_insp` inspection record to validate
+            (e.g. `"mod_insp__baselibs__feat_arc"`).
+        src: Label of a `needs_json` build output containing the inspection record
             and the full link graph. Defaults to the calling package's
             `//:needs_json`.
         link_fields: Sphinx-needs link fields followed recursively from the root
@@ -558,14 +558,14 @@ def architecture_checklist(
         cmd = """
         $(location {validate_tool}) \
             --needs-json $(location {src})/needs.json \
-            --checklist-id '{checklist_id}' \
+            --checklist-id '{mod_insp_id}' \
             --output $@ \
             {link_args} \
             {extra_args} \
             {dep_args}
         """.format(
             validate_tool = validate_tool,
-            checklist_id = checklist_id,
+            mod_insp_id = mod_insp_id,
             src = src,
             link_args = link_args,
             extra_args = extra_args,

--- a/docs.bzl
+++ b/docs.bzl
@@ -577,155 +577,52 @@ def architecture_checklist(
 
 def score_component(
         name,
-        component = None,
-        req_insp_id = None,
-        arc_insp_id = None,
-        src = "//:needs_json",
-        extra_needs = [],
+        req_chklst = [],
+        arch_chklst = [],
         visibility = None):
     """Bundle the requirement and architecture checklists of a single component.
 
-    Creates the component requirement/architecture extraction targets plus their
-    inspection-record checklists and aggregates the two checklists into a single
-    target `name`. Building `name` builds both the component requirements
-    checklist and the component architecture checklist, so the build fails when
-    either drifts from its reviewed inspection record.
-
-    The following targets are generated:
-
-    * `<name>_comp_reqs`      - extracted component requirements
-    * `<name>_req_checklist`  - requirements inspection-record checklist
-    * `<name>_comp_arch`      - extracted component architecture
-    * `<name>_arch_checklist` - architecture inspection-record checklist
-    * `<name>`                - filegroup bundling both checklists
+    The checklist targets are defined explicitly in the BUILD file (typically
+    `requirements_checklist` and `architecture_checklist`) and referenced here.
+    Building `name` builds every referenced checklist, so the build fails when
+    any of them drifts from its reviewed inspection record.
 
     Args:
-        name: Name of the aggregate target and prefix for the generated targets.
-        component: Component name used to filter needs. Defaults to `name`.
-        req_insp_id: Id of the `mod_insp` record for the component requirements.
-            Defaults to `mod_insp__<component>__comp_req`.
-        arc_insp_id: Id of the `mod_insp` record for the component architecture.
-            Defaults to `mod_insp__<component>__comp_arc`.
-        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
-        extra_needs: Additional `needs_json` build outputs forwarded to both
-            checklists (e.g. `["@score_platform//:needs_json"]`).
-        visibility: Standard Bazel visibility for the generated targets.
+        name: Name of the aggregate target.
+        req_chklst: Labels of the component requirements checklist targets.
+        arch_chklst: Labels of the component architecture checklist targets.
+        visibility: Standard Bazel visibility for the generated target.
     """
-    component = component or name
-    req_insp_id = req_insp_id or "mod_insp__{}__comp_req".format(component)
-    arc_insp_id = arc_insp_id or "mod_insp__{}__comp_arc".format(component)
-
-    component_requirements(
-        name = name + "_comp_reqs",
-        src = src,
-        component = component,
-        visibility = visibility,
-    )
-    requirements_checklist(
-        name = name + "_req_checklist",
-        mod_insp_id = req_insp_id,
-        deps = [":" + name + "_comp_reqs"],
-        extra_needs = extra_needs,
-        visibility = visibility,
-    )
-    component_architecture(
-        name = name + "_comp_arch",
-        src = src,
-        component = component,
-        visibility = visibility,
-    )
-    architecture_checklist(
-        name = name + "_arch_checklist",
-        mod_insp_id = arc_insp_id,
-        deps = [":" + name + "_comp_arch"],
-        extra_needs = extra_needs,
-        visibility = visibility,
-    )
     native.filegroup(
         name = name,
-        srcs = [
-            ":" + name + "_req_checklist",
-            ":" + name + "_arch_checklist",
-        ],
+        srcs = req_chklst + arch_chklst,
         visibility = visibility,
     )
 
 def score_module(
         name,
-        feature = None,
+        req_chklst = [],
+        arch_chklst = [],
         components = [],
-        req_insp_id = None,
-        arc_insp_id = None,
-        src = "//:needs_json",
-        extra_needs = [],
         visibility = None):
     """Bundle the feature checklists of a module with all of its components.
 
-    Creates the feature requirement/architecture extraction targets plus their
-    inspection-record checklists and aggregates them with every component listed
-    in `components` into a single target `name`. Building `name` builds the
-    feature requirements checklist, the feature architecture checklist and all
-    referenced component targets, so the build fails when any of them drifts from
-    its reviewed inspection record.
-
-    The following targets are generated:
-
-    * `<name>_feature_reqs`   - extracted feature requirements
-    * `<name>_req_checklist`  - feature requirements inspection-record checklist
-    * `<name>_feature_arch`   - extracted feature architecture
-    * `<name>_arch_checklist` - feature architecture inspection-record checklist
-    * `<name>`                - filegroup bundling both checklists and components
+    The checklist targets are defined explicitly in the BUILD file (typically
+    `requirements_checklist` and `architecture_checklist`) and referenced here.
+    Building `name` builds the referenced feature checklists and every component
+    listed in `components`, so the build fails when any of them drifts from its
+    reviewed inspection record.
 
     Args:
-        name: Name of the aggregate target and prefix for the generated targets.
-        feature: Feature name used to filter needs. Defaults to `name`.
+        name: Name of the aggregate target.
+        req_chklst: Labels of the feature requirements checklist targets.
+        arch_chklst: Labels of the feature architecture checklist targets.
         components: Labels of `score_component` targets making up this module.
-            All of them are built together with the module checklists.
-        req_insp_id: Id of the `mod_insp` record for the feature requirements.
-            Defaults to `mod_insp__<feature>__feat_req`.
-        arc_insp_id: Id of the `mod_insp` record for the feature architecture.
-            Defaults to `mod_insp__<feature>__feat_arc`.
-        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
-        extra_needs: Additional `needs_json` build outputs forwarded to both
-            checklists (e.g. `["@score_platform//:needs_json"]`).
-        visibility: Standard Bazel visibility for the generated targets.
+        visibility: Standard Bazel visibility for the generated target.
     """
-    feature = feature or name
-    req_insp_id = req_insp_id or "mod_insp__{}__feat_req".format(feature)
-    arc_insp_id = arc_insp_id or "mod_insp__{}__feat_arc".format(feature)
-
-    feature_requirements(
-        name = name + "_feature_reqs",
-        src = src,
-        feature = feature,
-        visibility = visibility,
-    )
-    requirements_checklist(
-        name = name + "_req_checklist",
-        mod_insp_id = req_insp_id,
-        deps = [":" + name + "_feature_reqs"],
-        extra_needs = extra_needs,
-        visibility = visibility,
-    )
-    feature_architecture(
-        name = name + "_feature_arch",
-        src = src,
-        feature = feature,
-        visibility = visibility,
-    )
-    architecture_checklist(
-        name = name + "_arch_checklist",
-        mod_insp_id = arc_insp_id,
-        deps = [":" + name + "_feature_arch"],
-        extra_needs = extra_needs,
-        visibility = visibility,
-    )
     native.filegroup(
         name = name,
-        srcs = [
-            ":" + name + "_req_checklist",
-            ":" + name + "_arch_checklist",
-        ] + components,
+        srcs = req_chklst + arch_chklst + components,
         visibility = visibility,
     )
 

--- a/docs.bzl
+++ b/docs.bzl
@@ -63,8 +63,10 @@ def _rewrite_needs_json_to_sourcelinks(labels):
         s = str(x)
         if s.endswith("//:needs_json"):
             out.append(s.replace("//:needs_json", "//:sourcelinks_json"))
+
         #Items which do not end up with '//:needs_json' shall not be appended to 'out'.
         #They are treated separately and are not related to source code linking.
+
     return out
 
 def _merge_sourcelinks(name, sourcelinks, known_good = None):
@@ -319,19 +321,90 @@ def sphinx_needs_to_trlc(
         visibility = visibility,
     )
 
+def requirements_checklist(
+        name,
+        checklist_id,
+        deps,
+        src = "//:needs_json",
+        visibility = None):
+    """Validate a requirement checklist (`req_chklst`) against its build output.
+
+    Building this target recomputes the SHA256 over the concatenated outputs of
+    `deps` and compares it to the `sha256` attribute of the `req_chklst` need
+    `checklist_id` (looked up in `src`'s `needs.json`). The build **fails** when
+    the hashes differ, i.e. when a validated target output has changed since the
+    checklist was last reviewed.
+
+    Typical usage validates the extracted requirements of a component against the
+    checklist that reviewed them:
+
+        component_requirements(
+            name = "bitmanipulation_comp_reqs",
+            component = "bitmanipulation",
+        )
+
+        requirements_checklist(
+            name = "bitmanipulation_req_checklist",
+            checklist_id = "req_chklst__bitmanipulation__comp_req",
+            deps = [":bitmanipulation_comp_reqs"],
+        )
+
+    Run with `bazel build //:bitmanipulation_req_checklist`. On the first run (or
+    after the requirements change) the build fails and prints the actual SHA256;
+    copy it into the `sha256` attribute of the checklist need once the checklist
+    has been (re-)reviewed.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.sha256`.
+        checklist_id: Id of the `req_chklst` need to validate
+            (e.g. `"req_chklst__bitmanipulation__comp_req"`).
+        deps: List of labels whose outputs are hashed and validated. Usually a
+            single `component_requirements`/`filtered_needs_json` target.
+        src: Label of a `needs_json` build output containing the checklist need.
+            Defaults to the calling package's `//:needs_json`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    validate_tool = Label("//scripts_bazel:validate_checklist")
+
+    dep_args = " ".join(["$(locations %s)" % d for d in deps])
+
+    native.genrule(
+        name = name,
+        srcs = [src] + deps,
+        outs = [name + ".sha256"],
+        cmd = """
+        $(location {validate_tool}) \
+            --needs-json $(location {src})/needs.json \
+            --checklist-id '{checklist_id}' \
+            --output $@ \
+            {dep_args}
+        """.format(
+            validate_tool = validate_tool,
+            checklist_id = checklist_id,
+            src = src,
+            dep_args = dep_args,
+        ),
+        tools = [validate_tool],
+        visibility = visibility,
+    )
+
 def _missing_requirements(deps):
     """Add Python hub dependencies if they are missing."""
     found = []
     missing = []
+
     def _target_to_packagename(target):
         return str(target).split("/")[-1].split(":")[0]
+
     all_packages = [_target_to_packagename(pkg) for pkg in all_requirements]
+
     def _find(pkg):
         for dep in deps:
             dep_pkg = _target_to_packagename(dep)
             if dep_pkg == pkg:
                 return True
         return False
+
     for pkg in all_packages:
         if _find(pkg):
             found.append(pkg)
@@ -453,7 +526,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = docs_data,
         deps = deps,
-        env = docs_env
+        env = docs_env,
     )
 
     docs_sources_env["ACTION"] = "incremental"
@@ -463,7 +536,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = combo_data,
         deps = deps,
-        env = docs_sources_env
+        env = docs_sources_env,
     )
 
     native.alias(
@@ -479,7 +552,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = docs_data,
         deps = deps,
-        env = docs_env
+        env = docs_env,
     )
 
     docs_env["ACTION"] = "check"
@@ -489,7 +562,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = docs_data,
         deps = deps,
-        env = docs_env
+        env = docs_env,
     )
 
     docs_env["ACTION"] = "live_preview"
@@ -499,7 +572,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = docs_data,
         deps = deps,
-        env = docs_env
+        env = docs_env,
     )
 
     docs_sources_env["ACTION"] = "live_preview"
@@ -509,7 +582,7 @@ def docs(source_dir = "docs", data = [], deps = [], scan_code = [], known_good =
         srcs = [incremental_src],
         data = combo_data,
         deps = deps,
-        env = docs_sources_env
+        env = docs_sources_env,
     )
 
     py_venv(

--- a/docs.bzl
+++ b/docs.bzl
@@ -276,9 +276,12 @@ def component_architecture(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         component: Optional component name. If given, only component architecture
-            elements named with that component (per the `<type>__<name>__...`
-            convention) are kept; if omitted, all component architecture
-            elements are kept.
+            elements named with that component are kept; component architecture
+            IDs follow the `<type>__<feature>__<component>` convention (e.g.
+            `comp_arc_sta__baselibs__bit_manipulation`) and any underscores in
+            the component segment are removed for matching (so `bit_manipulation`
+            matches the component name `bitmanipulation`). If omitted, all
+            component architecture elements are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
@@ -575,10 +578,220 @@ def architecture_checklist(
         visibility = visibility,
     )
 
+def dfa_checklist(
+        name,
+        deps,
+        mod_insp_id,
+        src = "//:needs_json",
+        link_fields = ["mitigates", "violates", "fulfils", "includes", "uses", "provides", "derived_from", "satisfies", "covers"],
+        extra_needs = [],
+        visibility = None):
+    """Validate a DFA inspection record against its build output.
+
+    Building this target recomputes the SHA256 over the DFA elements in `deps`
+    and, by default, over everything they depend on transitively, and compares
+    it to the `sha256` attribute of the `mod_insp` inspection record
+    `mod_insp_id`. The build **fails** when a validated DFA element *or one of
+    its (recursive) dependencies* changed since the inspection was last reviewed.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.sha256`.
+        deps: List of labels whose outputs define the root elements that are
+            hashed and validated. Usually the feature/component architecture and
+            requirements the DFA covers (e.g. `feature_architecture` /
+            `feature_requirements` targets).
+        mod_insp_id: Id of the `mod_insp` inspection record to validate.
+        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
+        link_fields: Sphinx-needs link fields followed recursively to include
+            (transitive) dependencies in the hash. Set to `[]` to hash only the
+            elements in `deps`.
+        extra_needs: Additional `needs_json` build outputs providing external
+            needs referenced but not contained in `src`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    validate_tool = Label("//scripts_bazel:validate_checklist")
+
+    dep_args = " ".join(["$(locations %s)" % d for d in deps])
+    link_args = " ".join(["--link-field '%s'" % f for f in link_fields])
+    extra_args = " ".join(["--extra-needs-json $(location %s)/needs.json" % e for e in extra_needs])
+
+    native.genrule(
+        name = name,
+        srcs = [src] + extra_needs + deps,
+        outs = [name + ".sha256"],
+        cmd = """
+        $(location {validate_tool}) \
+            --needs-json $(location {src})/needs.json \
+            --checklist-id '{mod_insp_id}' \
+            --output $@ \
+            {link_args} \
+            {extra_args} \
+            {dep_args}
+        """.format(
+            validate_tool = validate_tool,
+            mod_insp_id = mod_insp_id,
+            src = src,
+            link_args = link_args,
+            extra_args = extra_args,
+            dep_args = dep_args,
+        ),
+        tools = [validate_tool],
+        visibility = visibility,
+    )
+
+def fmea_checklist(
+        name,
+        deps,
+        mod_insp_id,
+        src = "//:needs_json",
+        link_fields = ["mitigates", "violates", "fulfils", "includes", "uses", "provides", "derived_from", "satisfies", "covers"],
+        extra_needs = [],
+        visibility = None):
+    """Validate an FMEA inspection record against its build output.
+
+    Building this target recomputes the SHA256 over the FMEA elements in `deps`
+    and, by default, over everything they depend on transitively, and compares
+    it to the `sha256` attribute of the `mod_insp` inspection record
+    `mod_insp_id`. The build **fails** when a validated FMEA element *or one of
+    its (recursive) dependencies* changed since the inspection was last reviewed.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.sha256`.
+        deps: List of labels whose outputs define the root elements that are
+            hashed and validated. Usually the feature/component architecture and
+            requirements the FMEA covers (e.g. `feature_architecture` /
+            `feature_requirements` targets).
+        mod_insp_id: Id of the `mod_insp` inspection record to validate.
+        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
+        link_fields: Sphinx-needs link fields followed recursively to include
+            (transitive) dependencies in the hash. Set to `[]` to hash only the
+            elements in `deps`.
+        extra_needs: Additional `needs_json` build outputs providing external
+            needs referenced but not contained in `src`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    validate_tool = Label("//scripts_bazel:validate_checklist")
+
+    dep_args = " ".join(["$(locations %s)" % d for d in deps])
+    link_args = " ".join(["--link-field '%s'" % f for f in link_fields])
+    extra_args = " ".join(["--extra-needs-json $(location %s)/needs.json" % e for e in extra_needs])
+
+    native.genrule(
+        name = name,
+        srcs = [src] + extra_needs + deps,
+        outs = [name + ".sha256"],
+        cmd = """
+        $(location {validate_tool}) \
+            --needs-json $(location {src})/needs.json \
+            --checklist-id '{mod_insp_id}' \
+            --output $@ \
+            {link_args} \
+            {extra_args} \
+            {dep_args}
+        """.format(
+            validate_tool = validate_tool,
+            mod_insp_id = mod_insp_id,
+            src = src,
+            link_args = link_args,
+            extra_args = extra_args,
+            dep_args = dep_args,
+        ),
+        tools = [validate_tool],
+        visibility = visibility,
+    )
+
+def verification_report(
+        name,
+        deps,
+        mod_ver_report_id,
+        src = "//:needs_json",
+        link_fields = ["mitigates", "violates", "fulfils", "includes", "uses", "provides", "derived_from", "satisfies", "covers"],
+        extra_needs = [],
+        visibility = None):
+    """Validate a module verification report record against its build output.
+
+    Works exactly like `dfa_checklist`/`fmea_checklist`, but validates a
+    `mod_ver_report` instead of a `mod_insp`. Building this target recomputes the
+    SHA256 over the elements in `deps` and, by default, over everything they
+    depend on transitively, and compares it to the `sha256` attribute of the
+    verification report record `mod_ver_report_id`. The build **fails** when a
+    covered element *or one of its (recursive) dependencies* changed since the
+    report was last reviewed.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.sha256`.
+        deps: List of labels whose outputs define the root elements that are
+            hashed and validated (e.g. the verified requirements/architecture).
+        mod_ver_report_id: Id of the `mod_ver_report` record to validate.
+        src: Label of a `needs_json` build output. Defaults to `//:needs_json`.
+        link_fields: Sphinx-needs link fields followed recursively to include
+            (transitive) dependencies in the hash. Set to `[]` to hash only the
+            elements in `deps`.
+        extra_needs: Additional `needs_json` build outputs providing external
+            needs referenced but not contained in `src`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    validate_tool = Label("//scripts_bazel:validate_checklist")
+
+    dep_args = " ".join(["$(locations %s)" % d for d in deps])
+    link_args = " ".join(["--link-field '%s'" % f for f in link_fields])
+    extra_args = " ".join(["--extra-needs-json $(location %s)/needs.json" % e for e in extra_needs])
+
+    native.genrule(
+        name = name,
+        srcs = [src] + extra_needs + deps,
+        outs = [name + ".sha256"],
+        cmd = """
+        $(location {validate_tool}) \
+            --needs-json $(location {src})/needs.json \
+            --checklist-id '{mod_ver_report_id}' \
+            --output $@ \
+            {link_args} \
+            {extra_args} \
+            {dep_args}
+        """.format(
+            validate_tool = validate_tool,
+            mod_ver_report_id = mod_ver_report_id,
+            src = src,
+            link_args = link_args,
+            extra_args = extra_args,
+            dep_args = dep_args,
+        ),
+        tools = [validate_tool],
+        visibility = visibility,
+    )
+
+def _emit_module_subtargets(name, visibility, single_labels, label_lists):
+    """Emit per-argument `<name>.<arg>` sub-targets for an aggregate target.
+
+    Single-label arguments (`single_labels`) become an `alias`, label-list
+    arguments (`label_lists`) become a `filegroup`. A sub-target is only created
+    when its argument is actually provided (non-`None` / non-empty list), so a
+    `<name>.<arg>` target exists exactly when `<arg>` is part of the aggregate.
+    Sub-targets carry the aggregate's `visibility`, exposing otherwise private
+    building blocks through the aggregate.
+    """
+    for arg, label in single_labels.items():
+        if label:
+            native.alias(
+                name = name + "." + arg,
+                actual = label,
+                visibility = visibility,
+            )
+    for arg, labels in label_lists.items():
+        if labels:
+            native.filegroup(
+                name = name + "." + arg,
+                srcs = labels,
+                visibility = visibility,
+            )
+
 def score_component(
         name,
         req_chklst = [],
         arch_chklst = [],
+        dfa = None,
+        fmea = None,
         visibility = None):
     """Bundle the requirement and architecture checklists of a single component.
 
@@ -587,23 +800,53 @@ def score_component(
     Building `name` builds every referenced checklist, so the build fails when
     any of them drifts from its reviewed inspection record.
 
+    In addition to the aggregate `name`, a `<name>.<arg>` sub-target is emitted
+    for every provided argument (e.g. `<name>.req_chklst`,
+    `<name>.arch_chklst`, `<name>.dfa`, `<name>.fmea`), so a single part can be
+    referenced through the component while the underlying targets stay private.
+    A sub-target only exists when its argument is part of the component.
+
     Args:
         name: Name of the aggregate target.
         req_chklst: Labels of the component requirements checklist targets.
         arch_chklst: Labels of the component architecture checklist targets.
+        dfa: Label of the dependent failure analysis target. Built together with
+            the component.
+        fmea: Label of the FMEA safety analysis target. Built together with the
+            component.
         visibility: Standard Bazel visibility for the generated target.
     """
+    extra = []
+    for d in [dfa, fmea]:
+        if d and d not in extra:
+            extra.append(d)
     native.filegroup(
         name = name,
-        srcs = req_chklst + arch_chklst,
+        srcs = req_chklst + arch_chklst + extra,
         visibility = visibility,
+    )
+    _emit_module_subtargets(
+        name = name,
+        visibility = visibility,
+        single_labels = {
+            "dfa": dfa,
+            "fmea": fmea,
+        },
+        label_lists = {
+            "req_chklst": req_chklst,
+            "arch_chklst": arch_chklst,
+        },
     )
 
 def score_module(
         name,
+        docs,
         req_chklst = [],
         arch_chklst = [],
         components = [],
+        verif_report = None,
+        dfa = None,
+        fmea = None,
         visibility = None):
     """Bundle the feature checklists of a module with all of its components.
 
@@ -613,18 +856,52 @@ def score_module(
     listed in `components`, so the build fails when any of them drifts from its
     reviewed inspection record.
 
+    In addition to the aggregate `name`, a `<name>.<arg>` sub-target is emitted
+    for every provided argument (e.g. `<name>.docs`, `<name>.req_chklst`,
+    `<name>.dfa`, `<name>.fmea`, `<name>.verif_report`), so a single part can be
+    referenced through the module while the underlying targets stay private. A
+    sub-target only exists when its argument is part of the module.
+
     Args:
         name: Name of the aggregate target.
+        docs: Label of the module documentation target (e.g. `//:docs`).
+            Mandatory; built together with the module.
         req_chklst: Labels of the feature requirements checklist targets.
         arch_chklst: Labels of the feature architecture checklist targets.
         components: Labels of `score_component` targets making up this module.
+        verif_report: Label of the module verification report target. Built
+            together with the module.
+        dfa: Label of the dependent failure analysis target. Built together with
+            the module.
+        fmea: Label of the FMEA safety analysis target. Built together with the
+            module.
         visibility: Standard Bazel visibility for the generated target.
     """
+    extra = []
+    for d in [docs, verif_report, dfa, fmea]:
+        if d and d not in extra:
+            extra.append(d)
     native.filegroup(
         name = name,
-        srcs = req_chklst + arch_chklst + components,
+        srcs = req_chklst + arch_chklst + components + extra,
         visibility = visibility,
     )
+    _emit_module_subtargets(
+        name = name,
+        visibility = visibility,
+        single_labels = {
+            "docs": docs,
+            "verif_report": verif_report,
+            "dfa": dfa,
+            "fmea": fmea,
+        },
+        label_lists = {
+            "req_chklst": req_chklst,
+            "arch_chklst": arch_chklst,
+            "components": components,
+        },
+    )
+
 
 def _missing_requirements(deps):
     """Add Python hub dependencies if they are missing."""

--- a/docs.bzl
+++ b/docs.bzl
@@ -96,6 +96,229 @@ def _merge_sourcelinks(name, sourcelinks, known_good = None):
         tools = [merge_sourcelinks_tool],
     )
 
+def filtered_needs_json(
+        name,
+        src,
+        types = [],
+        components = [],
+        component_attr = "component",
+        visibility = None):
+    """Extract a subset of sphinx-needs elements from a needs.json file.
+
+    Produces a `<name>.json` file containing only the needs that match all of
+    the given filters. This is useful to hand a downstream consumer just the
+    elements (e.g. `feat_req`) of one or more particular components.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output (a directory containing
+            `needs.json`), e.g. `":needs_json"` or `"@score_process//:needs_json"`.
+        types: Optional list of sphinx-needs element types to keep
+            (e.g. `["feat_req", "comp_req"]`). If empty, all types are kept.
+        components: Optional list of component names to keep. If empty, all
+            components are kept.
+        component_attr: Need attribute matched against `components`.
+            Defaults to `"component"`.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filter_tool = Label("//scripts_bazel:filter_needs_json")
+
+    type_args = " ".join(["--type '%s'" % t for t in types])
+    component_args = " ".join(["--component '%s'" % c for c in components])
+
+    native.genrule(
+        name = name,
+        srcs = [src],
+        outs = [name + ".json"],
+        cmd = """
+        $(location {filter_tool}) \
+            --output $@ \
+            --component-attr '{component_attr}' \
+            {type_args} \
+            {component_args} \
+            $(location {src})/needs.json
+        """.format(
+            filter_tool = filter_tool,
+            component_attr = component_attr,
+            type_args = type_args,
+            component_args = component_args,
+            src = src,
+        ),
+        tools = [filter_tool],
+        visibility = visibility,
+    )
+
+def component_requirements(
+        name,
+        src = "//:needs_json",
+        component = None,
+        visibility = None):
+    """Extract the component requirements (`comp_req`) from a needs.json file.
+
+    Convenience wrapper around `filtered_needs_json`. Produces a `<name>.json`
+    file containing only `comp_req` elements.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output. Defaults to the calling
+            package's `//:needs_json`.
+        component: Optional component name. If given, only component requirements
+            tagged with that component are kept; if omitted, all component
+            requirements are kept.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filtered_needs_json(
+        name = name,
+        src = src,
+        types = ["comp_req"],
+        components = [component] if component else [],
+        component_attr = "tags",
+        visibility = visibility,
+    )
+
+def feature_requirements(
+        name,
+        src = "//:needs_json",
+        feature = None,
+        visibility = None):
+    """Extract the feature requirements (`feat_req`) from a needs.json file.
+
+    Convenience wrapper around `filtered_needs_json`. Produces a `<name>.json`
+    file containing only `feat_req` elements.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output. Defaults to the calling
+            package's `//:needs_json`.
+        feature: Optional feature name. If given, only feature requirements
+            tagged with that feature are kept; if omitted, all feature
+            requirements are kept.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filtered_needs_json(
+        name = name,
+        src = src,
+        types = ["feat_req"],
+        components = [feature] if feature else [],
+        component_attr = "tags",
+        visibility = visibility,
+    )
+
+def assumptions_of_use(
+        name,
+        src = "//:needs_json",
+        component = None,
+        visibility = None):
+    """Extract the assumptions of use (`aou_req`) from a needs.json file.
+
+    Convenience wrapper around `filtered_needs_json`. Produces a `<name>.json`
+    file containing only `aou_req` elements.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        src: Label of a `needs_json` build output. Defaults to the calling
+            package's `//:needs_json`.
+        component: Optional component name. If given, only assumptions of use
+            tagged with that component are kept; if omitted, all assumptions of
+            use are kept.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    filtered_needs_json(
+        name = name,
+        src = src,
+        types = ["aou_req"],
+        components = [component] if component else [],
+        component_attr = "tags",
+        visibility = visibility,
+    )
+
+def sphinx_needs_to_md(
+        name,
+        src,
+        title = "Sphinx-needs elements",
+        visibility = None):
+    """Render the sphinx-needs elements of a needs.json file as a Markdown document.
+
+    Produces a `<name>.md` file containing a human readable description of every
+    sphinx-needs element found in `src`. Typically `src` is the output of a
+    `filtered_needs_json` target, but any `needs.json`-style file works.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.md`.
+        src: Label of a needs.json file, e.g. a `filtered_needs_json` target
+            (`":my_feat_reqs"`) or a `needs_json` directory output.
+        title: Title rendered at the top of the generated document.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    sphinx_needs_to_md_tool = Label("//scripts_bazel:sphinx_needs_to_md")
+
+    native.genrule(
+        name = name,
+        srcs = [src],
+        outs = [name + ".md"],
+        cmd = """
+        $(location {sphinx_needs_to_md_tool}) \
+            --output $@ \
+            --title '{title}' \
+            $(location {src})
+        """.format(
+            sphinx_needs_to_md_tool = sphinx_needs_to_md_tool,
+            title = title,
+            src = src,
+        ),
+        tools = [sphinx_needs_to_md_tool],
+        visibility = visibility,
+    )
+
+def sphinx_needs_to_trlc(
+        name,
+        src,
+        package = "Needs",
+        visibility = None):
+    """Convert the requirement sphinx-needs elements of a needs.json file into TRLC.
+
+    TRLC ("Treat Requirements Like Code",
+    https://github.com/bmw-software-engineering/trlc) is requirements-only tooling.
+    Only the S-CORE requirement element types are converted; everything else is
+    ignored:
+
+    * `feat_req` -> `ScoreReq.FeatReq` (feature requirement)
+    * `comp_req` -> `ScoreReq.CompReq` (component requirement)
+    * `aou_req`  -> `ScoreReq.AoU`     (assumption of use)
+
+    Produces a `<name>.trlc` data file in package `package` targeting the S-CORE
+    requirements metamodel (package `ScoreReq`) from
+    https://github.com/eclipse-score/tooling/tree/main/bazel/rules/rules_score/trlc.
+    Validate the output together with that metamodel (e.g. via `trlc_requirements`
+    using `score_requirements_model` as `spec`).
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.trlc`.
+        src: Label of a needs.json file, e.g. a `filtered_needs_json` target
+            (`":my_feat_reqs"`) or a `needs_json` directory output.
+        package: TRLC package name used for the generated requirements.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    sphinx_needs_to_trlc_tool = Label("//scripts_bazel:sphinx_needs_to_trlc")
+
+    native.genrule(
+        name = name,
+        srcs = [src],
+        outs = [name + ".trlc"],
+        cmd = """
+        $(location {sphinx_needs_to_trlc_tool}) \
+            --output $@ \
+            --package '{package}' \
+            $(location {src})
+        """.format(
+            sphinx_needs_to_trlc_tool = sphinx_needs_to_trlc_tool,
+            package = package,
+            src = src,
+        ),
+        tools = [sphinx_needs_to_trlc_tool],
+        visibility = visibility,
+    )
+
 def _missing_requirements(deps):
     """Add Python hub dependencies if they are missing."""
     found = []

--- a/docs.bzl
+++ b/docs.bzl
@@ -102,14 +102,13 @@ def filtered_needs_json(
         name,
         src,
         types = [],
-        components = [],
-        component_attr = "component",
+        names = [],
         visibility = None):
     """Extract a subset of sphinx-needs elements from a needs.json file.
 
     Produces a `<name>.json` file containing only the needs that match all of
     the given filters. This is useful to hand a downstream consumer just the
-    elements (e.g. `feat_req`) of one or more particular components.
+    elements (e.g. `feat_req`) of one or more particular features/components.
 
     Args:
         name: Name of the generated target. The output file is `<name>.json`.
@@ -117,16 +116,16 @@ def filtered_needs_json(
             `needs.json`), e.g. `":needs_json"` or `"@score_process//:needs_json"`.
         types: Optional list of sphinx-needs element types to keep
             (e.g. `["feat_req", "comp_req"]`). If empty, all types are kept.
-        components: Optional list of component names to keep. If empty, all
-            components are kept.
-        component_attr: Need attribute matched against `components`.
-            Defaults to `"component"`.
+        names: Optional list of feature/component names to keep, matched against
+            the second `__`-separated segment of each need ID (the
+            `<type>__<name>__...` naming convention). If empty, all
+            features/components are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filter_tool = Label("//scripts_bazel:filter_needs_json")
 
     type_args = " ".join(["--type '%s'" % t for t in types])
-    component_args = " ".join(["--component '%s'" % c for c in components])
+    name_args = " ".join(["--name '%s'" % n for n in names])
 
     native.genrule(
         name = name,
@@ -135,15 +134,13 @@ def filtered_needs_json(
         cmd = """
         $(location {filter_tool}) \
             --output $@ \
-            --component-attr '{component_attr}' \
             {type_args} \
-            {component_args} \
+            {name_args} \
             $(location {src})/needs.json
         """.format(
             filter_tool = filter_tool,
-            component_attr = component_attr,
             type_args = type_args,
-            component_args = component_args,
+            name_args = name_args,
             src = src,
         ),
         tools = [filter_tool],
@@ -165,16 +162,16 @@ def component_requirements(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         component: Optional component name. If given, only component requirements
-            tagged with that component are kept; if omitted, all component
-            requirements are kept.
+            named with that component (per the `<type>__<name>__...`
+            convention) are kept; if omitted, all component requirements are
+            kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
         name = name,
         src = src,
         types = ["comp_req"],
-        components = [component] if component else [],
-        component_attr = "tags",
+        names = [component] if component else [],
         visibility = visibility,
     )
 
@@ -193,16 +190,15 @@ def feature_requirements(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         feature: Optional feature name. If given, only feature requirements
-            tagged with that feature are kept; if omitted, all feature
-            requirements are kept.
+            named with that feature (per the `<type>__<name>__...` convention)
+            are kept; if omitted, all feature requirements are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
         name = name,
         src = src,
         types = ["feat_req"],
-        components = [feature] if feature else [],
-        component_attr = "tags",
+        names = [feature] if feature else [],
         visibility = visibility,
     )
 
@@ -221,16 +217,15 @@ def assumptions_of_use(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         component: Optional component name. If given, only assumptions of use
-            tagged with that component are kept; if omitted, all assumptions of
-            use are kept.
+            named with that component (per the `<type>__<name>__...`
+            convention) are kept; if omitted, all assumptions of use are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
         name = name,
         src = src,
         types = ["aou_req"],
-        components = [component] if component else [],
-        component_attr = "tags",
+        names = [component] if component else [],
         visibility = visibility,
     )
 
@@ -251,16 +246,16 @@ def feature_architecture(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         feature: Optional feature name. If given, only feature architecture
-            elements tagged with that feature are kept; if omitted, all feature
-            architecture elements are kept.
+            elements named with that feature (per the `<type>__<name>__...`
+            convention) are kept; if omitted, all feature architecture elements
+            are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
         name = name,
         src = src,
         types = ["feat_arc_sta", "feat_arc_dyn"],
-        components = [feature] if feature else [],
-        component_attr = "tags",
+        names = [feature] if feature else [],
         visibility = visibility,
     )
 
@@ -281,16 +276,16 @@ def component_architecture(
         src: Label of a `needs_json` build output. Defaults to the calling
             package's `//:needs_json`.
         component: Optional component name. If given, only component architecture
-            elements tagged with that component are kept; if omitted, all
-            component architecture elements are kept.
+            elements named with that component (per the `<type>__<name>__...`
+            convention) are kept; if omitted, all component architecture
+            elements are kept.
         visibility: Standard Bazel visibility for the generated target.
     """
     filtered_needs_json(
         name = name,
         src = src,
         types = ["comp_arc_sta", "comp_arc_dyn"],
-        components = [component] if component else [],
-        component_attr = "tags",
+        names = [component] if component else [],
         visibility = visibility,
     )
 
@@ -386,14 +381,26 @@ def requirements_checklist(
         checklist_id,
         deps,
         src = "//:needs_json",
+        link_fields = ["derived_from", "satisfies", "covers"],
+        extra_needs = [],
         visibility = None):
     """Validate a requirement checklist (`req_chklst`) against its build output.
 
-    Building this target recomputes the SHA256 over the concatenated outputs of
-    `deps` and compares it to the `sha256` attribute of the `req_chklst` need
-    `checklist_id` (looked up in `src`'s `needs.json`). The build **fails** when
-    the hashes differ, i.e. when a validated target output has changed since the
-    checklist was last reviewed.
+    Building this target recomputes the SHA256 over the requirements in `deps`
+    **and**, by default, over everything they depend on transitively, and
+    compares it to the `sha256` attribute of the `req_chklst` need `checklist_id`
+    (looked up in `src`'s `needs.json`). The build **fails** when the hashes
+    differ, i.e. when a validated requirement *or one of its (recursive)
+    dependencies* has changed since the checklist was last reviewed.
+
+    The dependency graph is the sphinx-needs link graph: starting from the
+    requirements in `deps` (the *roots*), the `link_fields` (by default
+    `derived_from`, `satisfies` and `covers`) are followed recursively through
+    `src`'s `needs.json`. For feature requirements this means the linked
+    stakeholder requirements (and their parents in turn) are part of the hash, so
+    changing a relevant stakeholder requirement makes this checklist go out of
+    date. Pass `link_fields = []` to restore the old behaviour of hashing only
+    the requirements in `deps`.
 
     Typical usage validates the extracted requirements of a component against the
     checklist that reviewed them:
@@ -418,30 +425,50 @@ def requirements_checklist(
         name: Name of the generated target. The output file is `<name>.sha256`.
         checklist_id: Id of the `req_chklst` need to validate
             (e.g. `"req_chklst__bitmanipulation__comp_req"`).
-        deps: List of labels whose outputs are hashed and validated. Usually a
-            single `component_requirements`/`filtered_needs_json` target.
-        src: Label of a `needs_json` build output containing the checklist need.
-            Defaults to the calling package's `//:needs_json`.
+        deps: List of labels whose outputs define the root requirements that are
+            hashed and validated. Usually a single
+            `component_requirements`/`feature_requirements`/`filtered_needs_json`
+            target.
+        src: Label of a `needs_json` build output containing the checklist need
+            and the full link graph. Defaults to the calling package's
+            `//:needs_json`.
+        link_fields: Sphinx-needs link fields followed recursively from the root
+            requirements to include their (transitive) dependencies in the hash.
+            Defaults to `["derived_from", "satisfies", "covers"]`. Set to `[]` to
+            hash only the requirements in `deps`.
+        extra_needs: Optional list of additional `needs_json` build outputs that
+            provide the full content of needs referenced from the validated
+            requirements but not contained in `src` (e.g. stakeholder
+            requirements imported from an upstream repository). Without them such
+            external needs are hashed as `<MISSING>` and changes to them are not
+            detected. Typically the same upstream `needs_json` targets passed as
+            `data` to `docs(...)` (e.g. `["@score_platform//:needs_json"]`).
         visibility: Standard Bazel visibility for the generated target.
     """
     validate_tool = Label("//scripts_bazel:validate_checklist")
 
     dep_args = " ".join(["$(locations %s)" % d for d in deps])
+    link_args = " ".join(["--link-field '%s'" % f for f in link_fields])
+    extra_args = " ".join(["--extra-needs-json $(location %s)/needs.json" % e for e in extra_needs])
 
     native.genrule(
         name = name,
-        srcs = [src] + deps,
+        srcs = [src] + extra_needs + deps,
         outs = [name + ".sha256"],
         cmd = """
         $(location {validate_tool}) \
             --needs-json $(location {src})/needs.json \
             --checklist-id '{checklist_id}' \
             --output $@ \
+            {link_args} \
+            {extra_args} \
             {dep_args}
         """.format(
             validate_tool = validate_tool,
             checklist_id = checklist_id,
             src = src,
+            link_args = link_args,
+            extra_args = extra_args,
             dep_args = dep_args,
         ),
         tools = [validate_tool],
@@ -453,14 +480,27 @@ def architecture_checklist(
         checklist_id,
         deps,
         src = "//:needs_json",
+        link_fields = ["fulfils", "includes", "uses", "provides", "derived_from", "satisfies", "covers"],
+        extra_needs = [],
         visibility = None):
     """Validate an architecture checklist (`arch_chklst`) against its build output.
 
-    Building this target recomputes the SHA256 over the concatenated outputs of
-    `deps` and compares it to the `sha256` attribute of the `arch_chklst` need
-    `checklist_id` (looked up in `src`'s `needs.json`). The build **fails** when
-    the hashes differ, i.e. when a validated target output has changed since the
-    checklist was last reviewed.
+    Building this target recomputes the SHA256 over the architecture in `deps`
+    **and**, by default, over everything they depend on transitively, and
+    compares it to the `sha256` attribute of the `arch_chklst` need `checklist_id`
+    (looked up in `src`'s `needs.json`). The build **fails** when the hashes
+    differ, i.e. when a validated architecture element *or one of its (recursive)
+    dependencies* has changed since the checklist was last reviewed.
+
+    The dependency graph is the sphinx-needs link graph: starting from the
+    architecture elements in `deps` (the *roots*), the `link_fields` are followed
+    recursively through `src`'s `needs.json`. The defaults follow the structural
+    architecture links (`includes`, `uses`, `provides`) as well as `fulfils` and
+    the requirement links (`derived_from`, `satisfies`, `covers`), so the closure
+    reaches the fulfilled requirements and their parents. Changing a fulfilled
+    requirement (or a stakeholder requirement it derives from) therefore makes
+    this checklist go out of date. Pass `link_fields = []` to restore the old
+    behaviour of hashing only the elements in `deps`.
 
     Typical usage validates the extracted architecture of a component against the
     checklist that reviewed it:
@@ -485,31 +525,50 @@ def architecture_checklist(
         name: Name of the generated target. The output file is `<name>.sha256`.
         checklist_id: Id of the `arch_chklst` need to validate
             (e.g. `"arch_chklst__bitmanipulation__comp_arc"`).
-        deps: List of labels whose outputs are hashed and validated. Usually a
-            single `feature_architecture`/`component_architecture`/
-            `filtered_needs_json` target.
-        src: Label of a `needs_json` build output containing the checklist need.
-            Defaults to the calling package's `//:needs_json`.
+        deps: List of labels whose outputs define the root architecture elements
+            that are hashed and validated. Usually a single
+            `feature_architecture`/`component_architecture`/`filtered_needs_json`
+            target.
+        src: Label of a `needs_json` build output containing the checklist need
+            and the full link graph. Defaults to the calling package's
+            `//:needs_json`.
+        link_fields: Sphinx-needs link fields followed recursively from the root
+            architecture elements to include their (transitive) dependencies in
+            the hash. Defaults to the structural architecture links plus the
+            requirement links. Set to `[]` to hash only the elements in `deps`.
+        extra_needs: Optional list of additional `needs_json` build outputs that
+            provide the full content of needs referenced from the validated
+            architecture elements but not contained in `src` (e.g. feature
+            requirements imported from an upstream repository). Without them such
+            external needs are hashed as `<MISSING>` and changes to them are not
+            detected. Typically the same upstream `needs_json` targets passed as
+            `data` to `docs(...)` (e.g. `["@score_platform//:needs_json"]`).
         visibility: Standard Bazel visibility for the generated target.
     """
     validate_tool = Label("//scripts_bazel:validate_checklist")
 
     dep_args = " ".join(["$(locations %s)" % d for d in deps])
+    link_args = " ".join(["--link-field '%s'" % f for f in link_fields])
+    extra_args = " ".join(["--extra-needs-json $(location %s)/needs.json" % e for e in extra_needs])
 
     native.genrule(
         name = name,
-        srcs = [src] + deps,
+        srcs = [src] + extra_needs + deps,
         outs = [name + ".sha256"],
         cmd = """
         $(location {validate_tool}) \
             --needs-json $(location {src})/needs.json \
             --checklist-id '{checklist_id}' \
             --output $@ \
+            {link_args} \
+            {extra_args} \
             {dep_args}
         """.format(
             validate_tool = validate_tool,
             checklist_id = checklist_id,
             src = src,
+            link_args = link_args,
+            extra_args = extra_args,
             dep_args = dep_args,
         ),
         tools = [validate_tool],

--- a/docs.bzl
+++ b/docs.bzl
@@ -132,11 +132,13 @@ def filtered_needs_json(
         srcs = [src],
         outs = [name + ".json"],
         cmd = """
+        SRC="$(location {src})"
+        if [ -d "$$SRC" ]; then SRC="$$SRC/needs.json"; fi
         $(location {filter_tool}) \
             --output $@ \
             {type_args} \
             {name_args} \
-            $(location {src})/needs.json
+            "$$SRC"
         """.format(
             filter_tool = filter_tool,
             type_args = type_args,
@@ -330,6 +332,46 @@ def sphinx_needs_to_md(
         visibility = visibility,
     )
 
+def sphinx_needs_to_rst(
+        name,
+        src,
+        title = "Sphinx-needs elements",
+        visibility = None):
+    """Render the sphinx-needs elements of a needs.json file as reStructuredText.
+
+    Like `sphinx_needs_to_md`, but instead of a human readable description it
+    emits real sphinx-needs directives (`.. comp_req::`, `.. feat_req::`, ...).
+    The resulting `<name>.rst` file can be `include`d into a Sphinx project so
+    the needs are picked up by sphinx-needs itself. Typically `src` is the output
+    of a `filtered_needs_json` target, but any `needs.json`-style file works.
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.rst`.
+        src: Label of a needs.json file, e.g. a `filtered_needs_json` target
+            (`":my_feat_reqs"`) or a `needs_json` directory output.
+        title: Title rendered at the top of the generated document.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    sphinx_needs_to_rst_tool = Label("//scripts_bazel:sphinx_needs_to_rst")
+
+    native.genrule(
+        name = name,
+        srcs = [src],
+        outs = [name + ".rst"],
+        cmd = """
+        $(location {sphinx_needs_to_rst_tool}) \
+            --output $@ \
+            --title '{title}' \
+            $(location {src})
+        """.format(
+            sphinx_needs_to_rst_tool = sphinx_needs_to_rst_tool,
+            title = title,
+            src = src,
+        ),
+        tools = [sphinx_needs_to_rst_tool],
+        visibility = visibility,
+    )
+
 def sphinx_needs_to_trlc(
         name,
         src,
@@ -376,6 +418,59 @@ def sphinx_needs_to_trlc(
             src = src,
         ),
         tools = [sphinx_needs_to_trlc_tool],
+        visibility = visibility,
+    )
+
+def trlc_to_sphinx_needs(
+        name,
+        srcs,
+        project = "Needs",
+        visibility = None):
+    """Convert TRLC requirements into a sphinx-needs needs.json file.
+
+    Inverse of `sphinx_needs_to_trlc`. Reads one or more TRLC data files written
+    against the S-CORE requirements metamodel (package `ScoreReq`,
+    https://github.com/eclipse-score/tooling/blob/main/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl)
+    and emits the corresponding requirement sphinx-needs elements. Only the
+    S-CORE requirement object types are converted; everything else is ignored:
+
+    * `ScoreReq.FeatReq`          -> `feat_req` (feature requirement)
+    * `ScoreReq.CompReq`          -> `comp_req` (component requirement)
+    * `ScoreReq.AssumedSystemReq` -> `stkh_req` (stakeholder requirement)
+    * `ScoreReq.AoU`              -> `aou_req`  (assumption of use)
+
+    `derived_from` references are rendered as sphinx-needs links carrying a
+    version constraint (e.g. `FEAT_001[version==1]`). Passing the referenced
+    requirement files alongside the deriving ones (e.g. the feature requirements
+    a component requirement derives from) makes those links resolve within the
+    generated needs.json.
+
+    Produces a `<name>.json` needs.json file compatible with sphinx-needs and
+    the S-CORE metamodel (`score_metamodel`).
+
+    Args:
+        name: Name of the generated target. The output file is `<name>.json`.
+        srcs: Labels of the TRLC data files (`.trlc`) to convert. All referenced
+            requirements should be included so that `derived_from` links resolve.
+        project: Project name recorded in the generated needs.json.
+        visibility: Standard Bazel visibility for the generated target.
+    """
+    trlc_to_sphinx_needs_tool = Label("//scripts_bazel:trlc_to_sphinx_needs")
+
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        outs = [name + ".json"],
+        cmd = """
+        $(location {trlc_to_sphinx_needs_tool}) \
+            --output $@ \
+            --project '{project}' \
+            $(SRCS)
+        """.format(
+            trlc_to_sphinx_needs_tool = trlc_to_sphinx_needs_tool,
+            project = project,
+        ),
+        tools = [trlc_to_sphinx_needs_tool],
         visibility = visibility,
     )
 
@@ -792,6 +887,8 @@ def score_component(
         arch_chklst = [],
         dfa = None,
         fmea = None,
+        comp_reqs = None,
+        comp_arch = None,
         visibility = None):
     """Bundle the requirement and architecture checklists of a single component.
 
@@ -802,7 +899,8 @@ def score_component(
 
     In addition to the aggregate `name`, a `<name>.<arg>` sub-target is emitted
     for every provided argument (e.g. `<name>.req_chklst`,
-    `<name>.arch_chklst`, `<name>.dfa`, `<name>.fmea`), so a single part can be
+    `<name>.arch_chklst`, `<name>.dfa`, `<name>.fmea`, `<name>.comp_reqs`,
+    `<name>.comp_arch`), so a single part can be
     referenced through the component while the underlying targets stay private.
     A sub-target only exists when its argument is part of the component.
 
@@ -814,10 +912,18 @@ def score_component(
             the component.
         fmea: Label of the FMEA safety analysis target. Built together with the
             component.
+        comp_reqs: Optional label of a `component_requirements` target extracting
+            the component requirements (`comp_req`) sphinx-needs elements from a
+            needs.json file. Exposed as the `<name>.comp_reqs` sub-target and
+            built together with the component.
+        comp_arch: Optional label of a `component_architecture` target extracting
+            the component architecture (`comp_arc`) sphinx-needs elements from a
+            needs.json file. Exposed as the `<name>.comp_arch` sub-target and
+            built together with the component.
         visibility: Standard Bazel visibility for the generated target.
     """
     extra = []
-    for d in [dfa, fmea]:
+    for d in [dfa, fmea, comp_reqs, comp_arch]:
         if d and d not in extra:
             extra.append(d)
     native.filegroup(
@@ -831,6 +937,8 @@ def score_component(
         single_labels = {
             "dfa": dfa,
             "fmea": fmea,
+            "comp_reqs": comp_reqs,
+            "comp_arch": comp_arch,
         },
         label_lists = {
             "req_chklst": req_chklst,
@@ -847,6 +955,9 @@ def score_module(
         verif_report = None,
         dfa = None,
         fmea = None,
+        aous = None,
+        feat_arch = None,
+        feat_reqs = None,
         visibility = None):
     """Bundle the feature checklists of a module with all of its components.
 
@@ -858,9 +969,10 @@ def score_module(
 
     In addition to the aggregate `name`, a `<name>.<arg>` sub-target is emitted
     for every provided argument (e.g. `<name>.docs`, `<name>.req_chklst`,
-    `<name>.dfa`, `<name>.fmea`, `<name>.verif_report`), so a single part can be
-    referenced through the module while the underlying targets stay private. A
-    sub-target only exists when its argument is part of the module.
+    `<name>.dfa`, `<name>.fmea`, `<name>.verif_report`, `<name>.aous`,
+    `<name>.feat_arch`, `<name>.feat_reqs`), so a single part can be referenced
+    through the module while the underlying targets stay private. A sub-target
+    only exists when its argument is part of the module.
 
     Args:
         name: Name of the aggregate target.
@@ -875,10 +987,22 @@ def score_module(
             the module.
         fmea: Label of the FMEA safety analysis target. Built together with the
             module.
+        aous: Optional label of an `assumptions_of_use` target extracting the
+            assumptions of use (`aou_req`) sphinx-needs elements from a
+            needs.json file. Exposed as the `<name>.aous` sub-target and built
+            together with the module.
+        feat_arch: Optional label of a `feature_architecture` target extracting
+            the feature architecture (`feat_arc`) sphinx-needs elements from a
+            needs.json file. Exposed as the `<name>.feat_arch` sub-target and
+            built together with the module.
+        feat_reqs: Optional label of a `feature_requirements` target extracting
+            the feature requirements (`feat_req`) sphinx-needs elements from a
+            needs.json file. Exposed as the `<name>.feat_reqs` sub-target and
+            built together with the module.
         visibility: Standard Bazel visibility for the generated target.
     """
     extra = []
-    for d in [docs, verif_report, dfa, fmea]:
+    for d in [docs, verif_report, dfa, fmea, aous, feat_arch, feat_reqs]:
         if d and d not in extra:
             extra.append(d)
     native.filegroup(
@@ -894,6 +1018,9 @@ def score_module(
             "verif_report": verif_report,
             "dfa": dfa,
             "fmea": fmea,
+            "aous": aous,
+            "feat_arch": feat_arch,
+            "feat_reqs": feat_reqs,
         },
         label_lists = {
             "req_chklst": req_chklst,

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -46,6 +46,7 @@ This section provides an overview of current process requirements and their clar
   Req,     'tool_req__docs' in id and implemented == "YES" and "Requirements"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Requirements"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and              "Requirements" in tags and status == "valid", 'tool_req__docs' in id and              "Requirements" in tags and status != "valid"
   Arch,    'tool_req__docs' in id and implemented == "YES" and "Architecture"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Architecture"              in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and              "Architecture" in tags and status == "valid", 'tool_req__docs' in id and              "Architecture" in tags and status != "valid"
   DDesign, 'tool_req__docs' in id and implemented == "YES" and "Detailed Design & Code"    in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Detailed Design & Code"    in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and    "Detailed Design & Code" in tags and status == "valid", 'tool_req__docs' in id and    "Detailed Design & Code" in tags and status != "valid"
+  Verif,   'tool_req__docs' in id and implemented == "YES" and "Verification Evidence"      in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Verification Evidence"      in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and      "Verification Evidence" in tags and status == "valid", 'tool_req__docs' in id and      "Verification Evidence" in tags and status != "valid"
   TVR,     'tool_req__docs' in id and implemented == "YES" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and "Tool Verification Reports" in tags and status == "valid", 'tool_req__docs' in id and "Tool Verification Reports" in tags and status != "valid"
   Other,   'tool_req__docs' in id and implemented == "YES" and "Process / Other"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Process / Other"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and           "Process / Other" in tags and status == "valid", 'tool_req__docs' in id and           "Process / Other" in tags and status != "valid"
   SftyAn,  'tool_req__docs' in id and implemented == "YES" and "Safety Analysis"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "PARTIAL" and "Safety Analysis"           in tags and status == "valid", 'tool_req__docs' in id and implemented == "NO" and           "Safety Analysis" in tags and status == "valid", 'tool_req__docs' in id and           "Safety Analysis" in tags and status != "valid"
@@ -863,6 +864,47 @@ Testing
 
    Docs-AS-Code shall provide a way to gather statistics on linkages to implementation(source_code_links) & tests(testlink) for all needs.
    It shall also be possible to filter these by type and use the provided statistics in the documentation (via diagrams drawn from it etc.)
+
+🔎 Verification Evidence
+########################
+
+.. tool_req:: Support machine-readable module verification reports
+  :id: tool_req__docs_verification_report_need
+  :tags: Verification Evidence
+  :implemented: YES
+  :version: 1
+  :satisfies: gd_req__verification_reporting
+  :parent_covered: NO: process wording is broader than the currently modeled report artifact.
+
+  Docs-as-Code shall support a machine-readable module verification report need type.
+
+  The need type shall:
+
+  * use ``mod_ver_report`` as directive type
+  * classify the report by ``safety``, ``security``, ``status`` and ``verification_method``
+  * link the report to the verified module via ``belongs_to``
+  * allow links to contained verification evidence via ``contains``
+  * allow links to covered artifacts via ``covers``
+  * allow links to backing documents or work products via ``evidence`` and ``realizes``
+
+.. tool_req:: Support machine-readable inspection records
+  :id: tool_req__docs_inspection_record_need
+  :tags: Verification Evidence
+  :implemented: YES
+  :version: 1
+  :satisfies: gd_req__verification_checks
+  :parent_covered: NO: process wording defines verification checks, while the tool models a first-class inspection record artifact.
+
+  Docs-as-Code shall support a machine-readable inspection record need type.
+
+  The need type shall:
+
+  * use ``mod_insp`` as directive type
+  * classify the inspection by ``inspection_type`` and ``inspection_state``
+  * record the checklist reference and reviewer list via ``checklist_ref`` and ``reviewers``
+  * link the inspection to the verified module via ``belongs_to``
+  * link the inspected artifacts via ``inspects``
+  * allow links to backing evidence via ``evidence``
 
 🧪 Tool Verification Reports
 ############################

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -901,8 +901,10 @@ Testing
 
   * use ``mod_insp`` as directive type
   * classify the inspection by ``inspection_type`` and ``inspection_state``
-  * record the checklist reference and reviewer list via ``checklist_ref`` and ``reviewers``
+  * record the checklist template reference via ``checklist_template``
+  * record the reviewer list via ``reviewers``
   * link the inspection to the verified module via ``belongs_to``
+  * link the filled checklist document via ``checklist``
   * link the inspected artifacts via ``inspects``
   * allow links to backing evidence via ``evidence``
 

--- a/scripts_bazel/BUILD
+++ b/scripts_bazel/BUILD
@@ -45,3 +45,27 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [],
 )
+
+py_binary(
+    name = "filter_needs_json",
+    srcs = ["filter_needs_json.py"],
+    main = "filter_needs_json.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_binary(
+    name = "sphinx_needs_to_md",
+    srcs = ["sphinx_needs_to_md.py"],
+    main = "sphinx_needs_to_md.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_binary(
+    name = "sphinx_needs_to_trlc",
+    srcs = ["sphinx_needs_to_trlc.py"],
+    main = "sphinx_needs_to_trlc.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/scripts_bazel/BUILD
+++ b/scripts_bazel/BUILD
@@ -33,9 +33,9 @@ py_binary(
 py_binary(
     name = "merge_sourcelinks",
     srcs = ["merge_sourcelinks.py"],
-    deps= [ "//src/extensions/score_source_code_linker"],
     main = "merge_sourcelinks.py",
     visibility = ["//visibility:public"],
+    deps = ["//src/extensions/score_source_code_linker"],
 )
 
 py_binary(
@@ -66,6 +66,14 @@ py_binary(
     name = "sphinx_needs_to_trlc",
     srcs = ["sphinx_needs_to_trlc.py"],
     main = "sphinx_needs_to_trlc.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_binary(
+    name = "validate_checklist",
+    srcs = ["validate_checklist.py"],
+    main = "validate_checklist.py",
     visibility = ["//visibility:public"],
     deps = [],
 )

--- a/scripts_bazel/BUILD
+++ b/scripts_bazel/BUILD
@@ -63,9 +63,25 @@ py_binary(
 )
 
 py_binary(
+    name = "sphinx_needs_to_rst",
+    srcs = ["sphinx_needs_to_rst.py"],
+    main = "sphinx_needs_to_rst.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_binary(
     name = "sphinx_needs_to_trlc",
     srcs = ["sphinx_needs_to_trlc.py"],
     main = "sphinx_needs_to_trlc.py",
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+py_binary(
+    name = "trlc_to_sphinx_needs",
+    srcs = ["trlc_to_sphinx_needs.py"],
+    main = "trlc_to_sphinx_needs.py",
     visibility = ["//visibility:public"],
     deps = [],
 )

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -17,6 +17,9 @@ the backing Python tools (in this folder) to:
 2. **Render** the selected elements as a human readable Markdown document.
 3. **Convert** S-CORE requirement elements into [TRLC](https://github.com/bmw-software-engineering/trlc)
    data targeting the S-CORE requirements metamodel.
+4. **Validate** a reviewable *requirement checklist* against the build output it
+   was reviewed against, by pinning a SHA256 hash in a `req_chklst` sphinx-needs
+   element and failing the build when the output drifts.
 
 The goal is to show how requirements managed as sphinx-needs can be bridged to
 other consumers (review docs, TRLC-based tooling) without manual copying.
@@ -33,14 +36,24 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 | `assumptions_of_use` | `<name>.json` | Convenience wrapper for `aou_req` elements. |
 | `sphinx_needs_to_md` | `<name>.md` | Render needs as a Markdown document. |
 | `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
+| `requirements_checklist` | `<name>.sha256` | Validate a `req_chklst` need against its target output via SHA256. |
 
 ### Python tools (`scripts_bazel/`)
 
 - [filter_needs_json.py](filter_needs_json.py) — extract a subset of needs.
 - [sphinx_needs_to_md.py](sphinx_needs_to_md.py) — render needs as Markdown.
 - [sphinx_needs_to_trlc.py](sphinx_needs_to_trlc.py) — convert needs to TRLC.
+- [validate_checklist.py](validate_checklist.py) — validate a checklist hash.
 
 The matching `py_binary` targets are declared in [BUILD](BUILD).
+
+### Metamodel
+
+A new `req_chklst` need type is added in
+[metamodel.yaml](../src/extensions/score_metamodel/metamodel.yaml). It carries a
+mandatory `sha256` attribute, an optional `targets` attribute (the Bazel labels
+it validates), and an optional `checklist` link to the rendered checklist
+document.
 
 ## How to use
 
@@ -81,3 +94,54 @@ bazel build //path/to:my_feature_reqs_trlc
 
 You can also call `filtered_needs_json` directly for full control over the
 `types`, `components`, and `component_attr` filters.
+
+## Requirement checklists
+
+A *requirement checklist* couples a human review (a checklist `.rst` document)
+with the exact build output that was reviewed. The state of that output is
+pinned via a SHA256 hash stored on a `req_chklst` sphinx-needs element. When the
+output later changes, the checklist is considered stale and the build fails
+until the checklist is re-reviewed and the hash updated.
+
+### 1. Declare the checklist need
+
+Add a `req_chklst` element (e.g. next to the checklist `.rst`). It references the
+checklist document, the validated Bazel target(s), and the expected hash:
+
+```rst
+.. req_chklst:: Bitmanipulation Component Requirements Checklist
+   :id: req_chklst__bitmanipulation__comp_req
+   :status: valid
+   :checklist: doc__bitmanipulation_req_inspection
+   :targets: //:bitmanipulation_comp_reqs
+   :sha256: 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+### 2. Declare the validation target
+
+```starlark
+load("@docs-as-code//:docs.bzl", "component_requirements", "requirements_checklist")
+
+component_requirements(
+    name = "bitmanipulation_comp_reqs",
+    component = "bitmanipulation",
+)
+
+requirements_checklist(
+    name = "bitmanipulation_req_checklist",
+    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    deps = [":bitmanipulation_comp_reqs"],
+)
+```
+
+### 3. Validate
+
+```bash
+bazel build //:bitmanipulation_req_checklist
+```
+
+The build hashes the `deps` output and compares it to the `sha256` on the
+checklist need. On the first run (placeholder hash) the build **fails** and
+prints the actual hash — review the checklist, then paste that hash into the
+`sha256` attribute. From then on the build passes until the validated
+requirements change again, at which point it fails and asks for a re-review.

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -17,9 +17,9 @@ the backing Python tools (in this folder) to:
 2. **Render** the selected elements as a human readable Markdown document.
 3. **Convert** S-CORE requirement elements into [TRLC](https://github.com/bmw-software-engineering/trlc)
    data targeting the S-CORE requirements metamodel.
-4. **Validate** a reviewable *requirement checklist* against the build output it
-   was reviewed against, by pinning a SHA256 hash in a `req_chklst` sphinx-needs
-   element and failing the build when the output drifts.
+4. **Validate** a reviewable *requirement / architecture checklist* against the
+   build output it was reviewed against, by pinning a SHA256 hash on a
+   `mod_insp` inspection record and failing the build when the output drifts.
 
 The goal is to show how requirements managed as sphinx-needs can be bridged to
 other consumers (review docs, TRLC-based tooling) without manual copying.
@@ -38,8 +38,8 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 | `component_architecture` | `<name>.json` | Convenience wrapper for `comp_arc_sta` / `comp_arc_dyn` elements. |
 | `sphinx_needs_to_md` | `<name>.md` | Render needs as a Markdown document. |
 | `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
-| `requirements_checklist` | `<name>.sha256` | Validate a `req_chklst` need against its target output via SHA256. |
-| `architecture_checklist` | `<name>.sha256` | Validate an `arch_chklst` need against its target output via SHA256. |
+| `requirements_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its requirements target output via SHA256. |
+| `architecture_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its architecture target output via SHA256. |
 
 ### Python tools (`scripts_bazel/`)
 
@@ -52,15 +52,12 @@ The matching `py_binary` targets are declared in [BUILD](BUILD).
 
 ### Metamodel
 
-A new `req_chklst` need type is added in
-[metamodel.yaml](../src/extensions/score_metamodel/metamodel.yaml). It carries a
-mandatory `sha256` attribute, an optional `targets` attribute (the Bazel labels
-it validates), and an optional `checklist` link to the rendered checklist
-document.
-
-The analogous `arch_chklst` need type (validated by `architecture_checklist`)
-is defined in the same file and works the same way for feature/component
-architecture outputs.
+The `mod_insp` inspection record need type in
+[metamodel.yaml](../src/extensions/score_metamodel/metamodel.yaml) carries an
+optional `sha256` attribute (the reviewed build output hash), a mandatory
+`checklist` link to the rendered checklist document, and an `inspects` link to
+the inspected artifacts. The same need type is validated by both
+`requirements_checklist` and `architecture_checklist`.
 
 ## How to use
 
@@ -136,40 +133,57 @@ checklist is considered stale and the build fails until it is re-reviewed and th
 hash updated.
 
 There are two checklist kinds. They behave identically and differ only in the
-need type they pin and the macro that validates them:
+macro that validates them; both pin the reviewed state on a `mod_insp`
+inspection record:
 
 | Kind | Need type | Validating macro | Pins the reviewed state of … |
 | --- | --- | --- | --- |
-| Requirements | `req_chklst` | `requirements_checklist` | extracted requirements (`component_requirements` / `feature_requirements`) and, by default, their transitive dependencies |
-| Architecture | `arch_chklst` | `architecture_checklist` | extracted architecture (`component_architecture` / `feature_architecture`) and, by default, their transitive dependencies |
+| Requirements | `mod_insp` | `requirements_checklist` | extracted requirements (`component_requirements` / `feature_requirements`) and, by default, their transitive dependencies |
+| Architecture | `mod_insp` | `architecture_checklist` | extracted architecture (`component_architecture` / `feature_architecture`) and, by default, their transitive dependencies |
 
 The flow below is a complete, real example from the
 [baselibs](https://github.com/eclipse-score/baselibs) repository, which wires
 both kinds for its `bitmanipulation` component. You can copy it directly.
 
-### 1. Declare the checklist need
+### 1. Declare the inspection record need
 
-Add the checklist element next to the inspection `.rst`. It references the
-checklist document and the expected hash. On the
-first build leave the `sha256` as the placeholder (all zeros) and pin the real
-value afterwards.
+Add the `mod_insp` inspection record next to the inspection `.rst`. It links the
+inspected artifacts (`inspects`), the filled checklist document (`checklist`)
+and stores the expected hash. On the first build leave the `sha256` as the
+placeholder (all zeros) and pin the real value afterwards.
 
-Requirements (`req_chklst`):
+Requirements (`mod_insp`):
 
 ```rst
-.. req_chklst:: Bitmanipulation Component Requirements Checklist
-   :id: req_chklst__bitmanipulation__comp_req
+.. mod_insp:: Bitmanipulation Component Requirements Inspection Record
+   :id: mod_insp__bitmanipulation__comp_req
    :status: valid
+   :safety: ASIL_B
+   :security: YES
+   :inspection_type: requirements
+   :inspection_state: approved
+   :checklist_template: gd_chklst__req_inspection
+   :reviewers: mihajlo-k
+   :belongs_to: mod__baselibs
+   :inspects: comp_req__bitmanipulation__bit_operations
    :checklist: doc__bitmanipulation_req_inspection
    :sha256: 0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-Architecture (`arch_chklst`):
+Architecture (`mod_insp`):
 
 ```rst
-.. arch_chklst:: Bitmanipulation Component Architecture Checklist
-   :id: arch_chklst__bitmanipulation__comp_arc
+.. mod_insp:: Bitmanipulation Component Architecture Inspection Record
+   :id: mod_insp__bitmanipulation__comp_arc
    :status: valid
+   :safety: ASIL_B
+   :security: YES
+   :inspection_type: architecture
+   :inspection_state: approved
+   :checklist_template: gd_chklst__arch_inspection_checklist
+   :reviewers: aschemmel-tech
+   :belongs_to: mod__baselibs
+   :inspects: comp_arc_sta__bitmanipulation__component_view
    :checklist: doc__bitmanipulation_arc_inspection
    :sha256: 0000000000000000000000000000000000000000000000000000000000000000
 ```
@@ -191,7 +205,7 @@ component_requirements(
 
 requirements_checklist(
     name = "bitmanipulation_req_checklist",
-    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_req",
     deps = [":bitmanipulation_comp_reqs"],
     # Resolve upstream stakeholder requirements so changes to them are detected.
     extra_needs = ["@score_platform//:needs_json"],
@@ -210,7 +224,7 @@ component_architecture(
 
 architecture_checklist(
     name = "bitmanipulation_arch_checklist",
-    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_arc",
     deps = [":bitmanipulation_comp_arch"],
     # Resolve upstream (feature/stakeholder) requirements so changes are detected.
     extra_needs = ["@score_platform//:needs_json"],
@@ -274,7 +288,7 @@ transitively linked elements). Link targets carrying a version constraint
 # Component requirements: transitively pins feature + stakeholder requirements.
 requirements_checklist(
     name = "bitmanipulation_req_checklist",
-    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_req",
     deps = [":bitmanipulation_comp_reqs"],
     # default: link_fields = ["derived_from", "satisfies", "covers"]
 )
@@ -282,7 +296,7 @@ requirements_checklist(
 # Architecture: transitively pins fulfilled requirements (and their parents).
 architecture_checklist(
     name = "bitmanipulation_arch_checklist",
-    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_arc",
     deps = [":bitmanipulation_comp_arch"],
 )
 ```
@@ -310,14 +324,14 @@ pass as `data` to `docs(...)`:
 ```starlark
 requirements_checklist(
     name = "bitmanipulation_req_checklist",
-    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_req",
     deps = [":bitmanipulation_comp_reqs"],
     extra_needs = ["@score_platform//:needs_json"],
 )
 
 architecture_checklist(
     name = "bitmanipulation_arch_checklist",
-    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    mod_insp_id = "mod_insp__bitmanipulation__comp_arc",
     deps = [":bitmanipulation_comp_arch"],
     extra_needs = ["@score_platform//:needs_json"],
 )

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -100,7 +100,7 @@ bazel build //path/to:my_feature_reqs_trlc
 ```
 
 You can also call `filtered_needs_json` directly for full control over the
-`types`, `components`, and `component_attr` filters.
+`types` and `names` filters.
 
 ## Incremental builds and caching
 
@@ -121,33 +121,65 @@ In practice this means:
 
 - Changing an `.rst` file only re-runs the doc build plus the filtered targets
   whose content actually changed.
-- A `requirements_checklist` (or `architecture_checklist`) only re-validates —
-  and can only fail — when the requirements/architecture it pins really change.
-  Unrelated edits elsewhere in the documentation leave it untouched.
+- A `requirements_checklist` (or `architecture_checklist`) re-validates whenever
+  the full `needs.json` changes, but it only **fails** when the elements it pins
+  — the roots in `deps` *or any of their transitive dependencies* (see
+  [Transitive dependencies](#transitive-dependencies)) — really change. Edits to
+  unrelated, unreachable elements leave its hash untouched.
 
-## Requirement checklists
+## Checklists
 
-A *requirement checklist* couples a human review (a checklist `.rst` document)
-with the exact build output that was reviewed. The state of that output is
-pinned via a SHA256 hash stored on a `req_chklst` sphinx-needs element. When the
-output later changes, the checklist is considered stale and the build fails
-until the checklist is re-reviewed and the hash updated.
+A *checklist* couples a human review (a checklist `.rst` document) with the exact
+build output that was reviewed. The state of that output is pinned via a SHA256
+hash stored on a sphinx-needs element. When the output later changes, the
+checklist is considered stale and the build fails until it is re-reviewed and the
+hash updated.
+
+There are two checklist kinds. They behave identically and differ only in the
+need type they pin and the macro that validates them:
+
+| Kind | Need type | Validating macro | Pins the reviewed state of … |
+| --- | --- | --- | --- |
+| Requirements | `req_chklst` | `requirements_checklist` | extracted requirements (`component_requirements` / `feature_requirements`) and, by default, their transitive dependencies |
+| Architecture | `arch_chklst` | `architecture_checklist` | extracted architecture (`component_architecture` / `feature_architecture`) and, by default, their transitive dependencies |
+
+The flow below is a complete, real example from the
+[baselibs](https://github.com/eclipse-score/baselibs) repository, which wires
+both kinds for its `bitmanipulation` component. You can copy it directly.
 
 ### 1. Declare the checklist need
 
-Add a `req_chklst` element (e.g. next to the checklist `.rst`). It references the
-checklist document, the validated Bazel target(s), and the expected hash:
+Add the checklist element next to the inspection `.rst`. It references the
+checklist document and the expected hash. On the
+first build leave the `sha256` as the placeholder (all zeros) and pin the real
+value afterwards.
+
+Requirements (`req_chklst`):
 
 ```rst
 .. req_chklst:: Bitmanipulation Component Requirements Checklist
    :id: req_chklst__bitmanipulation__comp_req
    :status: valid
    :checklist: doc__bitmanipulation_req_inspection
-   :targets: //:bitmanipulation_comp_reqs
+   :sha256: 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+Architecture (`arch_chklst`):
+
+```rst
+.. arch_chklst:: Bitmanipulation Component Architecture Checklist
+   :id: arch_chklst__bitmanipulation__comp_arc
+   :status: valid
+   :checklist: doc__bitmanipulation_arc_inspection
    :sha256: 0000000000000000000000000000000000000000000000000000000000000000
 ```
 
 ### 2. Declare the validation target
+
+Extract the reviewed output (`component_*` wrapper) and validate it against the
+checklist need.
+
+Requirements `BUILD`:
 
 ```starlark
 load("@docs-as-code//:docs.bzl", "component_requirements", "requirements_checklist")
@@ -161,117 +193,16 @@ requirements_checklist(
     name = "bitmanipulation_req_checklist",
     checklist_id = "req_chklst__bitmanipulation__comp_req",
     deps = [":bitmanipulation_comp_reqs"],
+    # Resolve upstream stakeholder requirements so changes to them are detected.
+    extra_needs = ["@score_platform//:needs_json"],
 )
 ```
 
-### 3. Validate
-
-```bash
-bazel build //:bitmanipulation_req_checklist
-```
-
-The build hashes the `deps` output and compares it to the `sha256` on the
-checklist need. On the first run (placeholder hash) the build **fails** and
-prints the actual hash — review the checklist, then paste that hash into the
-`sha256` attribute. From then on the build passes until the validated
-requirements change again, at which point it fails and asks for a re-review.
-
-## Architecture checklists
-
-An *architecture checklist* works exactly like a requirement checklist, but
-pins the reviewed state of an *architecture* output (a feature or component
-architecture) instead of requirements. The review (a checklist `.rst`
-document) is coupled to the extracted architecture via a SHA256 hash stored on
-an `arch_chklst` sphinx-needs element. When the architecture later changes, the
-checklist is considered stale and the build fails until it is re-reviewed and
-the hash updated.
-
-### 1. Declare the checklist need
-
-Add an `arch_chklst` element (e.g. next to the architecture `.rst`). It
-references the checklist document, the validated Bazel target(s), and the
-expected hash:
-
-```rst
-.. arch_chklst:: Baselibs Feature Architecture Checklist
-   :id: arch_chklst__baselibs__feat_arc
-   :status: valid
-   :checklist: doc__baselibs_architecture
-   :targets: //:baselibs_feature_arch
-   :sha256: 0000000000000000000000000000000000000000000000000000000000000000
-```
-
-### 2. Declare the validation target
+Architecture `BUILD`:
 
 ```starlark
-load("@docs-as-code//:docs.bzl", "feature_architecture", "architecture_checklist")
+load("@docs-as-code//:docs.bzl", "component_architecture", "architecture_checklist")
 
-feature_architecture(
-    name = "baselibs_feature_arch",
-    feature = "baselibs",
-)
-
-architecture_checklist(
-    name = "baselibs_feat_arch_checklist",
-    checklist_id = "arch_chklst__baselibs__feat_arc",
-    deps = [":baselibs_feature_arch"],
-)
-```
-
-Use `component_architecture` instead of `feature_architecture` to validate a
-single component's architecture.
-
-### 3. Validate
-
-```bash
-bazel build //:baselibs_feat_arch_checklist
-```
-
-The build hashes the `deps` output and compares it to the `sha256` on the
-checklist need. On the first run (placeholder hash) the build **fails** and
-prints the actual hash — review the checklist, then paste that hash into the
-`sha256` attribute. From then on the build passes until the validated
-architecture changes again, at which point it fails and asks for a re-review.
-
-## Worked example: bitmanipulation (baselibs)
-
-The [baselibs](https://github.com/eclipse-score/baselibs) repository wires both
-checklist kinds for its `bitmanipulation` component. The flow below is a
-complete, real example that you can copy.
-
-### Requirements checklist
-
-`BUILD`:
-
-```starlark
-component_requirements(
-    name = "bitmanipulation_comp_reqs",
-    component = "bitmanipulation",
-)
-
-requirements_checklist(
-    name = "bitmanipulation_req_checklist",
-    checklist_id = "req_chklst__bitmanipulation__comp_req",
-    deps = [":bitmanipulation_comp_reqs"],
-)
-```
-
-Checklist need (next to the requirements inspection `.rst`):
-
-```rst
-.. req_chklst:: Bitmanipulation Component Requirements Checklist
-   :id: req_chklst__bitmanipulation__comp_req
-   :status: valid
-   :checklist: doc__bitmanipulation_req_inspection
-   :targets: //:bitmanipulation_comp_reqs
-   :sha256: <pinned after first build>
-```
-
-### Architecture checklist
-
-`BUILD`:
-
-```starlark
 component_architecture(
     name = "bitmanipulation_comp_arch",
     component = "bitmanipulation",
@@ -281,44 +212,152 @@ architecture_checklist(
     name = "bitmanipulation_arch_checklist",
     checklist_id = "arch_chklst__bitmanipulation__comp_arc",
     deps = [":bitmanipulation_comp_arch"],
+    # Resolve upstream (feature/stakeholder) requirements so changes are detected.
+    extra_needs = ["@score_platform//:needs_json"],
 )
 ```
 
-Checklist need (next to the architecture inspection `.rst`):
+Use the `feature_requirements` / `feature_architecture` wrappers instead of the
+`component_*` ones to validate a whole feature rather than a single component.
 
-```rst
-.. arch_chklst:: Bitmanipulation Component Architecture Checklist
-   :id: arch_chklst__bitmanipulation__comp_arc
-   :status: valid
-   :checklist: doc__bitmanipulation_arc_inspection
-   :targets: //:bitmanipulation_comp_arch
-   :sha256: <pinned after first build>
+The `extra_needs` argument is explained in
+[Resolving external needs (`extra_needs`)](#resolving-external-needs-extra_needs)
+below; drop it if all transitively linked elements live in the same repository.
+
+### 3. Validate
+
+```bash
+bazel build //:bitmanipulation_req_checklist
+bazel build //:bitmanipulation_arch_checklist
 ```
 
-### Gotcha: the component filter matches on `tags`
+The build hashes the `deps` output and compares it to the `sha256` on the
+checklist need. On the first run (placeholder hash) the build **fails** and
+prints the actual hash — review the checklist, then paste that hash into the
+`sha256` attribute. From then on the build passes until the validated
+requirements/architecture change again, at which point it fails and asks for a
+re-review.
 
-`component_requirements` / `component_architecture` keep only needs whose
-`tags` contain the requested component name (see
-[filtered_needs_json](filter_needs_json.py), `--component-attr tags`). In
-baselibs that tag is *not* set on each element directly — it is injected for a
-whole document via `needextend`, e.g. for the requirements:
+### Transitive dependencies
 
-```rst
-.. needextend:: "__bitmanipulation__" in id
-   :+tags: baselibs, bitmanipulation
+By default neither `requirements_checklist` nor `architecture_checklist` hash
+only the elements in `deps`; they also follow the elements' sphinx-needs links
+recursively and include every reachable element in the hash. The followed link
+fields are configurable via the `link_fields` argument:
+
+| Macro | Default `link_fields` |
+| --- | --- |
+| `requirements_checklist` | `derived_from`, `satisfies`, `covers` |
+| `architecture_checklist` | `fulfils`, `includes`, `uses`, `provides`, `derived_from`, `satisfies`, `covers` |
+
+The mechanism is generic and works for any element type and any link fields:
+
+- **Feature requirements** → linked **stakeholder requirements** (via
+  `derived_from`/`satisfies`) are part of the hash.
+- **Component requirements** → linked **feature requirements** (and their
+  stakeholder requirements in turn) are part of the hash. Just point `deps` at a
+  `component_requirements` target; the defaults already cover the
+  `comp_req → feat_req → stkh_req` chain.
+- **Architecture elements** → the requirements they `fulfils` (and those
+  requirements' parents) plus structurally linked architecture elements
+  (`includes`/`uses`/`provides`) are part of the hash.
+
+This means a checklist also goes out of date when an **upstream** dependency
+changes — e.g. when a stakeholder requirement that a feature requirement is
+`derived_from` is edited. The roots (the elements in `deps`) define the entry
+points; the validator walks the link graph in the full `needs.json` (`src`) and
+hashes the canonical serialization of the whole closure (roots + all
+transitively linked elements). Link targets carrying a version constraint
+(`stkh_req__foo[version==1]`) are matched against the plain need id.
+
+```starlark
+# Component requirements: transitively pins feature + stakeholder requirements.
+requirements_checklist(
+    name = "bitmanipulation_req_checklist",
+    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    deps = [":bitmanipulation_comp_reqs"],
+    # default: link_fields = ["derived_from", "satisfies", "covers"]
+)
+
+# Architecture: transitively pins fulfilled requirements (and their parents).
+architecture_checklist(
+    name = "bitmanipulation_arch_checklist",
+    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    deps = [":bitmanipulation_comp_arch"],
+)
 ```
 
-The architecture view ids do **not** contain `__bitmanipulation__` (they read
-`comp_arc_sta__baselibs__bit_manipulation`), so that `needextend` does not tag
-them and `component_architecture(component = "bitmanipulation")` would extract
-*zero* needs. Add a matching `needextend` in the architecture document so the
-views get the component tag:
+Pass `link_fields = []` to restore the old behaviour of hashing only the
+elements in `deps`. The full need dict of every element in the closure is
+hashed, so any change to a linked element — its content, attributes *or* links
+(including newly added/removed back-links) — triggers a re-review.
 
-```rst
-.. needextend:: docname is not None and "bitmanipulation" in docname and "architecture" in docname and type in ["comp_arc_sta", "comp_arc_dyn"]
-   :+tags: baselibs, bitmanipulation
+### Resolving external needs (`extra_needs`)
+
+The transitive closure is walked through the link graph of the checklist's
+`src` (`//:needs_json` by default). When a linked element lives in **another
+repository** — e.g. a component requirement is `derived_from` a stakeholder
+requirement that is imported from an upstream repo — that element's full content
+is not contained in the local `needs.json`. The validator then hashes it as
+`<MISSING>`, so **changes to such upstream elements go undetected** and the
+checklist does not go stale even though one of its (transitive) parents changed.
+
+Pass the upstream `needs_json` build outputs via `extra_needs` so the validator
+can resolve the full content of those external needs and include them in the
+hash. Typically these are the same upstream `needs_json` targets you already
+pass as `data` to `docs(...)`:
+
+```starlark
+requirements_checklist(
+    name = "bitmanipulation_req_checklist",
+    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    deps = [":bitmanipulation_comp_reqs"],
+    extra_needs = ["@score_platform//:needs_json"],
+)
+
+architecture_checklist(
+    name = "bitmanipulation_arch_checklist",
+    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    deps = [":bitmanipulation_comp_arch"],
+    extra_needs = ["@score_platform//:needs_json"],
+)
 ```
 
-After that, `bazel build //:bitmanipulation_comp_arch` keeps the architecture
-view(s) and the checklist validates as expected. If a `component_*` target
-unexpectedly extracts `0 needs`, check the `tags` of the elements first.
+`extra_needs` is available on both `requirements_checklist` and
+`architecture_checklist` and only fills in needs that are *missing* locally: the
+main `src` keeps precedence for local content, and the extracted root elements
+in `deps` keep precedence over both. You only need it when the closure reaches
+elements that are not defined in the checklist's own repository — if everything
+is local, leave it at its default (`[]`).
+
+
+
+### Gotcha: the feature/component filter matches on the need ID
+
+`component_requirements` / `component_architecture` /
+`feature_requirements` / `feature_architecture` keep only needs whose ID
+encodes the requested feature/component name. Need IDs follow the
+`<type>__<name>__<rest>` naming convention, so the second `__`-separated
+segment is the feature/component name (see
+[filtered_needs_json](filter_needs_json.py), `--name`). For example, the
+following all belong to `bitmanipulation`:
+
+```text
+comp_req__bitmanipulation__shift
+feat_arc_sta__bitmanipulation__static_view
+```
+
+The `comp_arc_sta` and `comp_arc_dyn` types are an exception: their IDs follow
+`<type>__<feature name>__<component name>`, so the *third* segment holds the
+component name used for matching. For example, the following belongs to the
+`filesystem` component:
+
+```text
+comp_arc_sta__baselibs__filesystem
+```
+
+No tags or `needextend` injection are required — extraction is driven purely by
+the ID. Just make sure each element's ID follows the convention with the
+intended feature/component name as its name segment. If a `component_*` /
+`feature_*` target unexpectedly extracts `0 needs`, check that the element IDs
+use the expected name segment.

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -34,9 +34,12 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 | `component_requirements` | `<name>.json` | Convenience wrapper for `comp_req` elements. |
 | `feature_requirements` | `<name>.json` | Convenience wrapper for `feat_req` elements. |
 | `assumptions_of_use` | `<name>.json` | Convenience wrapper for `aou_req` elements. |
+| `feature_architecture` | `<name>.json` | Convenience wrapper for `feat_arc_sta` / `feat_arc_dyn` elements. |
+| `component_architecture` | `<name>.json` | Convenience wrapper for `comp_arc_sta` / `comp_arc_dyn` elements. |
 | `sphinx_needs_to_md` | `<name>.md` | Render needs as a Markdown document. |
 | `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
 | `requirements_checklist` | `<name>.sha256` | Validate a `req_chklst` need against its target output via SHA256. |
+| `architecture_checklist` | `<name>.sha256` | Validate an `arch_chklst` need against its target output via SHA256. |
 
 ### Python tools (`scripts_bazel/`)
 
@@ -54,6 +57,10 @@ A new `req_chklst` need type is added in
 mandatory `sha256` attribute, an optional `targets` attribute (the Bazel labels
 it validates), and an optional `checklist` link to the rendered checklist
 document.
+
+The analogous `arch_chklst` need type (validated by `architecture_checklist`)
+is defined in the same file and works the same way for feature/component
+architecture outputs.
 
 ## How to use
 
@@ -94,6 +101,29 @@ bazel build //path/to:my_feature_reqs_trlc
 
 You can also call `filtered_needs_json` directly for full control over the
 `types`, `components`, and `component_attr` filters.
+
+## Incremental builds and caching
+
+Because every step is a separate Bazel target, Bazel only re-runs the work that
+is actually affected by a change. Edit any `.rst` file and the documentation
+build (the `needs_json` target) is re-executed, because its inputs changed.
+
+However, the filtering, rendering, conversion and checklist targets sit
+*downstream* of `needs_json` and Bazel compares their inputs before re-running
+them. If your edit does not touch a given subset — for example you change an
+unrelated feature and the `component_requirements` output for a component stays
+byte-for-byte identical — then that `component_requirements` target produces the
+same output as before, and **every target that depends on it
+(`sphinx_needs_to_md`, `sphinx_needs_to_trlc`, `requirements_checklist`, ...) is
+not re-executed**. Bazel serves their previous results from cache instead.
+
+In practice this means:
+
+- Changing an `.rst` file only re-runs the doc build plus the filtered targets
+  whose content actually changed.
+- A `requirements_checklist` (or `architecture_checklist`) only re-validates —
+  and can only fail — when the requirements/architecture it pins really change.
+  Unrelated edits elsewhere in the documentation leave it untouched.
 
 ## Requirement checklists
 
@@ -145,3 +175,150 @@ checklist need. On the first run (placeholder hash) the build **fails** and
 prints the actual hash — review the checklist, then paste that hash into the
 `sha256` attribute. From then on the build passes until the validated
 requirements change again, at which point it fails and asks for a re-review.
+
+## Architecture checklists
+
+An *architecture checklist* works exactly like a requirement checklist, but
+pins the reviewed state of an *architecture* output (a feature or component
+architecture) instead of requirements. The review (a checklist `.rst`
+document) is coupled to the extracted architecture via a SHA256 hash stored on
+an `arch_chklst` sphinx-needs element. When the architecture later changes, the
+checklist is considered stale and the build fails until it is re-reviewed and
+the hash updated.
+
+### 1. Declare the checklist need
+
+Add an `arch_chklst` element (e.g. next to the architecture `.rst`). It
+references the checklist document, the validated Bazel target(s), and the
+expected hash:
+
+```rst
+.. arch_chklst:: Baselibs Feature Architecture Checklist
+   :id: arch_chklst__baselibs__feat_arc
+   :status: valid
+   :checklist: doc__baselibs_architecture
+   :targets: //:baselibs_feature_arch
+   :sha256: 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+### 2. Declare the validation target
+
+```starlark
+load("@docs-as-code//:docs.bzl", "feature_architecture", "architecture_checklist")
+
+feature_architecture(
+    name = "baselibs_feature_arch",
+    feature = "baselibs",
+)
+
+architecture_checklist(
+    name = "baselibs_feat_arch_checklist",
+    checklist_id = "arch_chklst__baselibs__feat_arc",
+    deps = [":baselibs_feature_arch"],
+)
+```
+
+Use `component_architecture` instead of `feature_architecture` to validate a
+single component's architecture.
+
+### 3. Validate
+
+```bash
+bazel build //:baselibs_feat_arch_checklist
+```
+
+The build hashes the `deps` output and compares it to the `sha256` on the
+checklist need. On the first run (placeholder hash) the build **fails** and
+prints the actual hash — review the checklist, then paste that hash into the
+`sha256` attribute. From then on the build passes until the validated
+architecture changes again, at which point it fails and asks for a re-review.
+
+## Worked example: bitmanipulation (baselibs)
+
+The [baselibs](https://github.com/eclipse-score/baselibs) repository wires both
+checklist kinds for its `bitmanipulation` component. The flow below is a
+complete, real example that you can copy.
+
+### Requirements checklist
+
+`BUILD`:
+
+```starlark
+component_requirements(
+    name = "bitmanipulation_comp_reqs",
+    component = "bitmanipulation",
+)
+
+requirements_checklist(
+    name = "bitmanipulation_req_checklist",
+    checklist_id = "req_chklst__bitmanipulation__comp_req",
+    deps = [":bitmanipulation_comp_reqs"],
+)
+```
+
+Checklist need (next to the requirements inspection `.rst`):
+
+```rst
+.. req_chklst:: Bitmanipulation Component Requirements Checklist
+   :id: req_chklst__bitmanipulation__comp_req
+   :status: valid
+   :checklist: doc__bitmanipulation_req_inspection
+   :targets: //:bitmanipulation_comp_reqs
+   :sha256: <pinned after first build>
+```
+
+### Architecture checklist
+
+`BUILD`:
+
+```starlark
+component_architecture(
+    name = "bitmanipulation_comp_arch",
+    component = "bitmanipulation",
+)
+
+architecture_checklist(
+    name = "bitmanipulation_arch_checklist",
+    checklist_id = "arch_chklst__bitmanipulation__comp_arc",
+    deps = [":bitmanipulation_comp_arch"],
+)
+```
+
+Checklist need (next to the architecture inspection `.rst`):
+
+```rst
+.. arch_chklst:: Bitmanipulation Component Architecture Checklist
+   :id: arch_chklst__bitmanipulation__comp_arc
+   :status: valid
+   :checklist: doc__bitmanipulation_arc_inspection
+   :targets: //:bitmanipulation_comp_arch
+   :sha256: <pinned after first build>
+```
+
+### Gotcha: the component filter matches on `tags`
+
+`component_requirements` / `component_architecture` keep only needs whose
+`tags` contain the requested component name (see
+[filtered_needs_json](filter_needs_json.py), `--component-attr tags`). In
+baselibs that tag is *not* set on each element directly — it is injected for a
+whole document via `needextend`, e.g. for the requirements:
+
+```rst
+.. needextend:: "__bitmanipulation__" in id
+   :+tags: baselibs, bitmanipulation
+```
+
+The architecture view ids do **not** contain `__bitmanipulation__` (they read
+`comp_arc_sta__baselibs__bit_manipulation`), so that `needextend` does not tag
+them and `component_architecture(component = "bitmanipulation")` would extract
+*zero* needs. Add a matching `needextend` in the architecture document so the
+views get the component tag:
+
+```rst
+.. needextend:: docname is not None and "bitmanipulation" in docname and "architecture" in docname and type in ["comp_arc_sta", "comp_arc_dyn"]
+   :+tags: baselibs, bitmanipulation
+```
+
+After that, `bazel build //:bitmanipulation_comp_arch` keeps the architecture
+view(s) and the checklist validates as expected. If a `component_*` target
+unexpectedly extracts `0 needs`, check the `tags` of the elements first.

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -1,0 +1,83 @@
+# Sphinx-needs processing rules (playground)
+
+> **WIP / demonstration only.** This branch (`ankr_rules_score_playground`) is a
+> proof of concept to explore how `rules_score` could post-process sphinx-needs
+> data. It is **not** production ready and is shared for demonstration purposes.
+
+## Why these changes
+
+The documentation build already produces a `needs.json` file that contains every
+sphinx-needs element (requirements, assumptions of use, ...). Downstream tooling
+often needs only a *subset* of that data, or the data in a *different format*.
+
+This change adds a small set of Bazel macros (in [docs.bzl](../docs.bzl)) plus
+the backing Python tools (in this folder) to:
+
+1. **Filter** a `needs.json` down to selected element types and/or components.
+2. **Render** the selected elements as a human readable Markdown document.
+3. **Convert** S-CORE requirement elements into [TRLC](https://github.com/bmw-software-engineering/trlc)
+   data targeting the S-CORE requirements metamodel.
+
+The goal is to show how requirements managed as sphinx-needs can be bridged to
+other consumers (review docs, TRLC-based tooling) without manual copying.
+
+## What was added
+
+### Bazel macros (`docs.bzl`)
+
+| Macro | Output | Purpose |
+| --- | --- | --- |
+| `filtered_needs_json` | `<name>.json` | Keep only needs matching the given `types` / `components`. |
+| `component_requirements` | `<name>.json` | Convenience wrapper for `comp_req` elements. |
+| `feature_requirements` | `<name>.json` | Convenience wrapper for `feat_req` elements. |
+| `assumptions_of_use` | `<name>.json` | Convenience wrapper for `aou_req` elements. |
+| `sphinx_needs_to_md` | `<name>.md` | Render needs as a Markdown document. |
+| `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
+
+### Python tools (`scripts_bazel/`)
+
+- [filter_needs_json.py](filter_needs_json.py) — extract a subset of needs.
+- [sphinx_needs_to_md.py](sphinx_needs_to_md.py) — render needs as Markdown.
+- [sphinx_needs_to_trlc.py](sphinx_needs_to_trlc.py) — convert needs to TRLC.
+
+The matching `py_binary` targets are declared in [BUILD](BUILD).
+
+## How to use
+
+In a `BUILD` file that already has a `needs_json` target, load the macros and
+chain them:
+
+```starlark
+load("@docs-as-code//:docs.bzl", "feature_requirements", "sphinx_needs_to_md", "sphinx_needs_to_trlc")
+
+# 1. Filter: keep only the feature requirements of one feature.
+feature_requirements(
+    name = "my_feature_reqs",
+    src = "//:needs_json",
+    feature = "my_feature",
+)
+
+# 2. Render the filtered set as Markdown.
+sphinx_needs_to_md(
+    name = "my_feature_reqs_md",
+    src = ":my_feature_reqs",
+    title = "My feature requirements",
+)
+
+# 3. Convert the filtered set to TRLC.
+sphinx_needs_to_trlc(
+    name = "my_feature_reqs_trlc",
+    src = ":my_feature_reqs",
+    package = "MyFeature",
+)
+```
+
+Build any of the targets to produce the corresponding output file:
+
+```bash
+bazel build //path/to:my_feature_reqs_md
+bazel build //path/to:my_feature_reqs_trlc
+```
+
+You can also call `filtered_needs_json` directly for full control over the
+`types`, `components`, and `component_attr` filters.

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -40,6 +40,11 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 | `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
 | `requirements_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its requirements target output via SHA256. |
 | `architecture_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its architecture target output via SHA256. |
+| `dfa_checklist` | `<name>.sha256` | Validate a `mod_insp` DFA record against its DFA target output via SHA256. |
+| `fmea_checklist` | `<name>.sha256` | Validate a `mod_insp` FMEA record against its FMEA target output via SHA256. |
+| `verification_report` | `<name>.sha256` | Validate a `mod_ver_report` record against its target output via SHA256. |
+| `score_component` | aggregate (`filegroup`) | Bundle a component's requirement + architecture checklists. |
+| `score_module` | aggregate (`filegroup`) | Bundle a feature's checklists (incl. DFA/FMEA), docs and all of its components. |
 
 ### Python tools (`scripts_bazel/`)
 
@@ -140,6 +145,9 @@ inspection record:
 | --- | --- | --- | --- |
 | Requirements | `mod_insp` | `requirements_checklist` | extracted requirements (`component_requirements` / `feature_requirements`) and, by default, their transitive dependencies |
 | Architecture | `mod_insp` | `architecture_checklist` | extracted architecture (`component_architecture` / `feature_architecture`) and, by default, their transitive dependencies |
+| DFA | `mod_insp` | `dfa_checklist` | the architecture/requirements the DFA covers (passed in `deps`) and, by default, their transitive dependencies |
+| FMEA | `mod_insp` | `fmea_checklist` | the architecture/requirements the FMEA covers (passed in `deps`) and, by default, their transitive dependencies |
+| Verification report | `mod_ver_report` | `verification_report` | the verified elements passed in `deps` and, by default, their transitive dependencies |
 
 The flow below is a complete, real example from the
 [baselibs](https://github.com/eclipse-score/baselibs) repository, which wires
@@ -263,6 +271,9 @@ fields are configurable via the `link_fields` argument:
 | --- | --- |
 | `requirements_checklist` | `derived_from`, `satisfies`, `covers` |
 | `architecture_checklist` | `fulfils`, `includes`, `uses`, `provides`, `derived_from`, `satisfies`, `covers` |
+| `dfa_checklist` | `mitigates`, `violates`, `fulfils`, `includes`, `uses`, `provides`, `derived_from`, `satisfies`, `covers` |
+| `fmea_checklist` | `mitigates`, `violates`, `fulfils`, `includes`, `uses`, `provides`, `derived_from`, `satisfies`, `covers` |
+| `verification_report` | `mitigates`, `violates`, `fulfils`, `includes`, `uses`, `provides`, `derived_from`, `satisfies`, `covers` |
 
 The mechanism is generic and works for any element type and any link fields:
 
@@ -338,12 +349,157 @@ architecture_checklist(
 ```
 
 `extra_needs` is available on both `requirements_checklist` and
-`architecture_checklist` and only fills in needs that are *missing* locally: the
+`architecture_checklist` (and on `dfa_checklist`, `fmea_checklist` and
+`verification_report`) and only fills in needs that are *missing* locally: the
 main `src` keeps precedence for local content, and the extracted root elements
 in `deps` keep precedence over both. You only need it when the closure reaches
 elements that are not defined in the checklist's own repository — if everything
 is local, leave it at its default (`[]`).
 
+## Safety analysis checklists (DFA / FMEA)
+
+`dfa_checklist` (Dependent Failure Analysis) and `fmea_checklist` (Failure Modes
+and Effects Analysis) work exactly like `requirements_checklist` /
+`architecture_checklist`: each pins the reviewed state of its safety-analysis
+elements on the `sha256` attribute of a `mod_insp` inspection record and fails
+the build when a validated element — or any of its transitive dependencies —
+changes after the last review.
+
+They differ only in their default `link_fields`: in addition to the architecture
+and requirement links, they also follow the safety links `mitigates` and
+`violates`, so an analysis goes stale when the architecture/requirements it
+mitigates or the failure modes it describes change. Wire them against the
+feature's architecture and requirements outputs:
+
+```starlark
+load("@docs-as-code//:docs.bzl", "feature_architecture", "feature_requirements", "dfa_checklist", "fmea_checklist")
+
+feature_architecture(
+    name = "baselibs_feature_arch",
+    src = "@score_platform//:needs_json",
+    feature = "baselibs",
+)
+
+feature_requirements(
+    name = "baselibs_feature_reqs",
+    src = "@score_platform//:needs_json",
+    feature = "baselibs",
+)
+
+dfa_checklist(
+    name = "baselibs_dfa_checklist",
+    mod_insp_id = "mod_insp__baselibs__feat_dfa",
+    deps = [":baselibs_feature_arch", ":baselibs_feature_reqs"],
+    extra_needs = ["@score_platform//:needs_json"],
+)
+
+fmea_checklist(
+    name = "baselibs_fmea_checklist",
+    mod_insp_id = "mod_insp__baselibs__feat_fmea",
+    deps = [":baselibs_feature_arch", ":baselibs_feature_reqs"],
+    extra_needs = ["@score_platform//:needs_json"],
+)
+```
+
+The `mod_insp` record is declared exactly like the requirements/architecture
+ones (see [Declare the inspection record need](#1-declare-the-inspection-record-need)),
+using `:inspection_type: dfa` / `fmea` and the matching
+`:checklist_template:` / `:inspects:` links. Validate and pin the hash the same
+way (build the target, paste the printed hash into `:sha256:`).
+
+## Verification report (`verification_report`)
+
+`verification_report` behaves identically to the safety-analysis checklists but
+validates a `mod_ver_report` record instead of a `mod_insp` one (pass its id via
+`mod_ver_report_id`). Use it to pin the reviewed state of the elements a module
+verification report covers:
+
+```starlark
+load("@docs-as-code//:docs.bzl", "verification_report")
+
+verification_report(
+    name = "baselibs_verification_report",
+    mod_ver_report_id = "mod_vrep__baselibs__module",
+    deps = [],
+    extra_needs = ["@score_platform//:needs_json"],
+)
+```
+
+## Module and component aggregates (`score_module` / `score_component`)
+
+`score_component` and `score_module` are convenience aggregates that bundle the
+individual checklist targets so a single `bazel build` covers a whole component
+or feature. Because building the aggregate builds every referenced checklist,
+the build fails when **any** of them drifts from its reviewed inspection record.
+
+- `score_component` bundles a component's requirement and architecture
+  checklists (`req_chklst`, `arch_chklst`) plus optional `dfa` / `fmea`
+  targets.
+- `score_module` bundles a feature's requirement and architecture checklists,
+  its `docs`, optional `dfa` / `fmea` / `verif_report` targets, and every
+  `score_component` listed in `components`. Building the module therefore builds
+  every component too.
+
+```starlark
+load("@docs-as-code//:docs.bzl", "score_component", "score_module")
+
+score_component(
+    name = "bitmanipulation",
+    req_chklst = [":bitmanipulation_req_checklist"],
+    arch_chklst = [":bitmanipulation_arch_checklist"],
+    dfa = ":bitmanipulation_dfa_checklist",
+    fmea = ":bitmanipulation_fmea_checklist",
+    visibility = ["//visibility:private"],
+)
+
+score_module(
+    name = "baselibs",
+    docs = ":docs",
+    req_chklst = [":baselibs_req_checklist"],
+    arch_chklst = [":baselibs_arch_checklist"],
+    components = [":bitmanipulation"],
+    dfa = ":baselibs_dfa_checklist",
+    fmea = ":baselibs_fmea_checklist",
+    # verif_report = ":baselibs_verification_report",
+    visibility = ["//visibility:public"],
+)
+```
+
+```bash
+# Build the whole module (feature checklists + docs + DFA/FMEA + all components).
+bazel build //:baselibs
+```
+
+### Sub-target aliases (`<name>.<arg>`)
+
+Both aggregates keep their underlying checklist targets private while still
+exposing each part individually. For every argument that is actually provided,
+a `<name>.<arg>` sub-target is generated with the aggregate's visibility:
+
+| Aggregate | Sub-targets |
+| --- | --- |
+| `score_component` | `<name>.req_chklst`, `<name>.arch_chklst`, `<name>.dfa`, `<name>.fmea` |
+| `score_module` | `<name>.docs`, `<name>.req_chklst`, `<name>.arch_chklst`, `<name>.components`, `<name>.dfa`, `<name>.fmea`, `<name>.verif_report` |
+
+Single-label arguments (`docs`, `dfa`, `fmea`, `verif_report`) become an
+`alias`; label-list arguments (`req_chklst`, `arch_chklst`, `components`) become
+a `filegroup`. A sub-target only exists when its argument is part of the
+aggregate, so referencing `<name>.fmea` on a module without an FMEA fails.
+
+This lets you build a single part through the module without depending on the
+private checklist target directly:
+
+```bash
+# Just the FMEA of the baselibs module.
+bazel build //:baselibs.fmea
+
+# Just the DFA, or just the docs.
+bazel build //:baselibs.dfa
+bazel build //:baselibs.docs
+
+# Just the requirement checklists of a component.
+bazel build //:bitmanipulation.req_chklst
+```
 
 
 ### Gotcha: the feature/component filter matches on the need ID

--- a/scripts_bazel/README_needs_rules.md
+++ b/scripts_bazel/README_needs_rules.md
@@ -37,6 +37,7 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 | `feature_architecture` | `<name>.json` | Convenience wrapper for `feat_arc_sta` / `feat_arc_dyn` elements. |
 | `component_architecture` | `<name>.json` | Convenience wrapper for `comp_arc_sta` / `comp_arc_dyn` elements. |
 | `sphinx_needs_to_md` | `<name>.md` | Render needs as a Markdown document. |
+| `sphinx_needs_to_rst` | `<name>.rst` | Render needs as reStructuredText sphinx-needs directives. |
 | `sphinx_needs_to_trlc` | `<name>.trlc` | Convert S-CORE requirements to TRLC. |
 | `requirements_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its requirements target output via SHA256. |
 | `architecture_checklist` | `<name>.sha256` | Validate a `mod_insp` record against its architecture target output via SHA256. |
@@ -50,6 +51,7 @@ other consumers (review docs, TRLC-based tooling) without manual copying.
 
 - [filter_needs_json.py](filter_needs_json.py) — extract a subset of needs.
 - [sphinx_needs_to_md.py](sphinx_needs_to_md.py) — render needs as Markdown.
+- [sphinx_needs_to_rst.py](sphinx_needs_to_rst.py) — render needs as sphinx-needs RST directives.
 - [sphinx_needs_to_trlc.py](sphinx_needs_to_trlc.py) — convert needs to TRLC.
 - [validate_checklist.py](validate_checklist.py) — validate a checklist hash.
 

--- a/scripts_bazel/filter_needs_json.py
+++ b/scripts_bazel/filter_needs_json.py
@@ -26,8 +26,10 @@ A need is kept when it matches *all* of the active filters:
   ``comp_arc_sta`` and ``comp_arc_dyn`` types are an exception: their IDs follow
   ``<type>__<feature name>__<component name>`` (e.g.
   ``comp_arc_sta__baselibs__filesystem``), so the *third* segment holds the
-  component name used for matching. If no ``--name`` is given, needs of any
-  feature/component are kept.
+  component name used for matching. Any underscores within that component
+  segment are removed before matching, so ``comp_arc_sta__baselibs__bit_manipulation``
+  matches the component name ``bitmanipulation``. If no ``--name`` is given,
+  needs of any feature/component are kept.
 
 The top-level structure of the needs.json file is preserved; only the per-need
 entries are filtered.
@@ -58,13 +60,15 @@ def _id_name_segment(need_id: str, need_type: str | None = None) -> str | None:
     types are an exception: their IDs follow
     ``<type>__<feature name>__<component name>`` (e.g.
     ``comp_arc_sta__baselibs__filesystem``), so the *third* segment holds the
-    component name. Returns ``None`` when the ID does not follow the convention.
+    component name. Any underscores within that component segment are removed,
+    so ``comp_arc_sta__baselibs__bit_manipulation`` yields ``bitmanipulation``.
+    Returns ``None`` when the ID does not follow the convention.
     """
     parts = need_id.split("__")
     if need_type in _COMPONENT_NAME_THIRD_SEGMENT_TYPES:
         if len(parts) < 3 or not parts[2]:
             return None
-        return parts[2]
+        return parts[2].replace("_", "")
     if len(parts) < 2 or not parts[1]:
         return None
     return parts[1]

--- a/scripts_bazel/filter_needs_json.py
+++ b/scripts_bazel/filter_needs_json.py
@@ -1,0 +1,166 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Extract a subset of sphinx-needs elements from a needs.json file.
+
+A need is kept when it matches *all* of the active filters:
+
+* ``--type``: the value of the need's ``type`` attribute is in the requested
+  list of element types (e.g. ``feat_req``). If no ``--type`` is given, needs
+  of any type are kept.
+* ``--component``: the value of the need's component attribute (configurable
+  via ``--component-attr``, default ``component``) matches one of the requested
+  component names. The attribute may hold a single string or a list of strings;
+  a need is kept when any of its values matches. If no ``--component`` is given,
+  needs of any component are kept.
+
+The top-level structure of the needs.json file is preserved; only the per-need
+entries are filtered.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _attribute_values(need: dict[str, Any], attr: str) -> list[str]:
+    """Return the values of ``attr`` on a need as a list of strings."""
+    value = need.get(attr)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value]  # pyright: ignore[reportUnknownVariableType]
+    return [str(value)]
+
+
+def _keep_need(
+    need: dict[str, Any],
+    types: set[str],
+    components: set[str],
+    component_attr: str,
+) -> bool:
+    if types and need.get("type") not in types:
+        return False
+    if components:
+        values = set(_attribute_values(need, component_attr))
+        if values.isdisjoint(components):
+            return False
+    return True
+
+
+def filter_needs(
+    data: dict[str, Any],
+    types: set[str],
+    components: set[str],
+    component_attr: str,
+) -> dict[str, Any]:
+    """Return a copy of ``data`` keeping only the needs that match the filters."""
+    for version in data.get("versions", {}).values():
+        needs = version.get("needs", {})
+        version["needs"] = {
+            need_id: need
+            for need_id, need in needs.items()
+            if _keep_need(need, types, components, component_attr)
+        }
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract a subset of sphinx-needs elements from a needs.json file."
+        )
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the filtered needs.json file to write.",
+    )
+    _ = parser.add_argument(
+        "--type",
+        dest="types",
+        action="append",
+        default=[],
+        metavar="ELEMENT_TYPE",
+        help=(
+            "Sphinx-needs element type to keep (e.g. 'feat_req'). "
+            "May be given multiple times. If omitted, all types are kept."
+        ),
+    )
+    _ = parser.add_argument(
+        "--component",
+        dest="components",
+        action="append",
+        default=[],
+        metavar="COMPONENT",
+        help=(
+            "Component name to keep. May be given multiple times. "
+            "If omitted, all components are kept."
+        ),
+    )
+    _ = parser.add_argument(
+        "--component-attr",
+        default="component",
+        help=(
+            "Need attribute matched against the values given via --component. "
+            "Defaults to 'component'."
+        ),
+    )
+    _ = parser.add_argument(
+        "input",
+        type=Path,
+        help="Input needs.json file to filter.",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    filtered = filter_needs(
+        data,
+        types=set(args.types),
+        components=set(args.components),
+        component_attr=args.component_attr,
+    )
+
+    kept = sum(
+        len(version.get("needs", {}))
+        for version in filtered.get("versions", {}).values()
+    )
+    logger.info(
+        "Filtered '%s' -> '%s' (%d needs kept, types=%s, components=%s)",
+        args.input,
+        args.output,
+        kept,
+        sorted(args.types) or "ALL",
+        sorted(args.components) or "ALL",
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(filtered, f, indent=2, sort_keys=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/filter_needs_json.py
+++ b/scripts_bazel/filter_needs_json.py
@@ -19,11 +19,15 @@ A need is kept when it matches *all* of the active filters:
 * ``--type``: the value of the need's ``type`` attribute is in the requested
   list of element types (e.g. ``feat_req``). If no ``--type`` is given, needs
   of any type are kept.
-* ``--component``: the value of the need's component attribute (configurable
-  via ``--component-attr``, default ``component``) matches one of the requested
-  component names. The attribute may hold a single string or a list of strings;
-  a need is kept when any of its values matches. If no ``--component`` is given,
-  needs of any component are kept.
+* ``--name``: the feature/component name encoded in the need's ID matches one
+  of the requested names. Need IDs follow the convention
+  ``<type>__<name>__<rest>`` (e.g. ``feat_req__baselibs__core_utilities``), so
+  the second ``__``-separated segment is the feature/component name. The
+  ``comp_arc_sta`` and ``comp_arc_dyn`` types are an exception: their IDs follow
+  ``<type>__<feature name>__<component name>`` (e.g.
+  ``comp_arc_sta__baselibs__filesystem``), so the *third* segment holds the
+  component name used for matching. If no ``--name`` is given, needs of any
+  feature/component are kept.
 
 The top-level structure of the needs.json file is preserved; only the per-need
 entries are filtered.
@@ -40,27 +44,43 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 
-def _attribute_values(need: dict[str, Any], attr: str) -> list[str]:
-    """Return the values of ``attr`` on a need as a list of strings."""
-    value = need.get(attr)
-    if value is None:
-        return []
-    if isinstance(value, list):
-        return [str(v) for v in value]  # pyright: ignore[reportUnknownVariableType]
-    return [str(value)]
+# Element types whose IDs follow ``<type>__<feature name>__<component name>``,
+# i.e. the component name used for matching is the *third* ``__`` segment.
+_COMPONENT_NAME_THIRD_SEGMENT_TYPES = frozenset({"comp_arc_sta", "comp_arc_dyn"})
+
+
+def _id_name_segment(need_id: str, need_type: str | None = None) -> str | None:
+    """Return the feature/component name encoded in a need ID.
+
+    Need IDs follow the convention ``<type>__<name>__<rest>`` (e.g.
+    ``feat_req__baselibs__core_utilities``); the second ``__``-separated segment
+    is the feature/component name. The ``comp_arc_sta`` and ``comp_arc_dyn``
+    types are an exception: their IDs follow
+    ``<type>__<feature name>__<component name>`` (e.g.
+    ``comp_arc_sta__baselibs__filesystem``), so the *third* segment holds the
+    component name. Returns ``None`` when the ID does not follow the convention.
+    """
+    parts = need_id.split("__")
+    if need_type in _COMPONENT_NAME_THIRD_SEGMENT_TYPES:
+        if len(parts) < 3 or not parts[2]:
+            return None
+        return parts[2]
+    if len(parts) < 2 or not parts[1]:
+        return None
+    return parts[1]
 
 
 def _keep_need(
+    need_id: str,
     need: dict[str, Any],
     types: set[str],
-    components: set[str],
-    component_attr: str,
+    names: set[str],
 ) -> bool:
     if types and need.get("type") not in types:
         return False
-    if components:
-        values = set(_attribute_values(need, component_attr))
-        if values.isdisjoint(components):
+    if names:
+        segment = _id_name_segment(need_id, need.get("type"))
+        if segment is None or segment not in names:
             return False
     return True
 
@@ -68,8 +88,7 @@ def _keep_need(
 def filter_needs(
     data: dict[str, Any],
     types: set[str],
-    components: set[str],
-    component_attr: str,
+    names: set[str],
 ) -> dict[str, Any]:
     """Return a copy of ``data`` keeping only the needs that match the filters."""
     for version in data.get("versions", {}).values():
@@ -77,7 +96,7 @@ def filter_needs(
         version["needs"] = {
             need_id: need
             for need_id, need in needs.items()
-            if _keep_need(need, types, components, component_attr)
+            if _keep_need(need_id, need, types, names)
         }
     return data
 
@@ -106,22 +125,16 @@ def main() -> int:
         ),
     )
     _ = parser.add_argument(
-        "--component",
-        dest="components",
+        "--name",
+        dest="names",
         action="append",
         default=[],
-        metavar="COMPONENT",
+        metavar="NAME",
         help=(
-            "Component name to keep. May be given multiple times. "
-            "If omitted, all components are kept."
-        ),
-    )
-    _ = parser.add_argument(
-        "--component-attr",
-        default="component",
-        help=(
-            "Need attribute matched against the values given via --component. "
-            "Defaults to 'component'."
+            "Feature/component name to keep, matched against the second "
+            "'__'-separated segment of each need ID (the '<type>__<name>__...' "
+            "naming convention). May be given multiple times. If omitted, all "
+            "features/components are kept."
         ),
     )
     _ = parser.add_argument(
@@ -138,8 +151,7 @@ def main() -> int:
     filtered = filter_needs(
         data,
         types=set(args.types),
-        components=set(args.components),
-        component_attr=args.component_attr,
+        names=set(args.names),
     )
 
     kept = sum(
@@ -147,12 +159,12 @@ def main() -> int:
         for version in filtered.get("versions", {}).values()
     )
     logger.info(
-        "Filtered '%s' -> '%s' (%d needs kept, types=%s, components=%s)",
+        "Filtered '%s' -> '%s' (%d needs kept, types=%s, names=%s)",
         args.input,
         args.output,
         kept,
         sorted(args.types) or "ALL",
-        sorted(args.components) or "ALL",
+        sorted(args.names) or "ALL",
     )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts_bazel/sphinx_needs_to_md.py
+++ b/scripts_bazel/sphinx_needs_to_md.py
@@ -1,0 +1,173 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Render the sphinx-needs elements of a needs.json file as a Markdown document.
+
+The input is a needs.json file (typically the output of ``filtered_needs_json``).
+Each need is rendered as a Markdown section. Needs are grouped by their ``type``
+and sorted by ``id`` so the output is stable and diff friendly.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Attributes rendered (in this order) as a table for every need.
+# Only attributes that are present and non-empty on a need are shown.
+_HEADER_ATTRS: list[tuple[str, str]] = [
+    ("title", "Title"),
+    ("type_name", "Type name"),
+    ("status", "Status"),
+    ("safety", "Safety"),
+    ("security", "Security"),
+    ("reqtype", "Requirement type"),
+    ("tags", "Tags"),
+    ("docname", "Document"),
+]
+
+
+def _format_value(value: object) -> str:
+    """Render an attribute value as a single line Markdown-safe string."""
+    text = (
+        ", ".join(str(v) for v in value)  # pyright: ignore[reportUnknownVariableType]
+        if isinstance(value, list)
+        else str(value)
+    )
+    # Escape the Markdown table cell separator.
+    return text.replace("|", "\\|")
+
+
+def _collect_needs(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all needs across every version, sorted by id."""
+    needs: list[dict[str, Any]] = []
+    for version in data.get("versions", {}).values():
+        needs.extend(version.get("needs", {}).values())
+    return sorted(needs, key=lambda need: str(need.get("id", "")))
+
+
+def _render_need(need: dict[str, Any]) -> str:
+    """Render a single need as a Markdown block."""
+    lines: list[str] = []
+    need_id = str(need.get("id", "<unknown id>"))
+    lines.append(f"### `{need_id}`")
+    lines.append("")
+
+    rows = [
+        (label, _format_value(value))
+        for attr, label in _HEADER_ATTRS
+        if (value := need.get(attr)) not in (None, "", [])
+    ]
+    if rows:
+        lines.append("| Attribute | Value |")
+        lines.append("| --- | --- |")
+        for label, value in rows:
+            lines.append(f"| {label} | {value} |")
+        lines.append("")
+
+    content = str(need.get("content", "")).strip()
+    if content:
+        lines.append("**Content:**")
+        lines.append("")
+        lines.append("```")
+        lines.extend(content.splitlines())
+        lines.append("```")
+    return "\n".join(lines).rstrip()
+
+
+def render_document(data: dict[str, Any], title: str) -> str:
+    """Render the whole needs document as Markdown."""
+    needs = _collect_needs(data)
+    types: dict[str, int] = {}
+    for need in needs:
+        type_ = str(need.get("type", "<no type>"))
+        types[type_] = types.get(type_, 0) + 1
+
+    blocks: list[str] = []
+    blocks.append(f"# {title}")
+    blocks.append(f"Total needs: **{len(needs)}**")
+
+    if types:
+        summary_lines = ["| Type | Count |", "| --- | --- |"]
+        summary_lines.extend(
+            f"| `{type_}` | {count} |" for type_, count in sorted(types.items())
+        )
+        blocks.append("\n".join(summary_lines))
+
+    current_type = None
+    for need in sorted(
+        needs, key=lambda n: (str(n.get("type", "")), str(n.get("id", "")))
+    ):
+        type_ = str(need.get("type", "<no type>"))
+        if type_ != current_type:
+            current_type = type_
+            blocks.append(f"## `{type_}`")
+        blocks.append(_render_need(need))
+
+    return "\n\n".join(blocks) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render the sphinx-needs elements of a needs.json file as Markdown."
+        )
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the Markdown file to write.",
+    )
+    _ = parser.add_argument(
+        "--title",
+        default="Sphinx-needs elements",
+        help="Title rendered at the top of the document.",
+    )
+    _ = parser.add_argument(
+        "input",
+        type=Path,
+        help="Input needs.json file to document.",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    document = render_document(data, title=args.title)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        _ = f.write(document)
+
+    need_count = sum(
+        len(version.get("needs", {})) for version in data.get("versions", {}).values()
+    )
+    logger.info(
+        "Documented '%s' -> '%s' (%d needs)",
+        args.input,
+        args.output,
+        need_count,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/sphinx_needs_to_rst.py
+++ b/scripts_bazel/sphinx_needs_to_rst.py
@@ -1,0 +1,184 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Render the sphinx-needs elements of a needs.json file as a reStructuredText
+document.
+
+The input is a needs.json file (typically the output of ``filtered_needs_json``).
+Unlike ``sphinx_needs_to_md`` -- which renders a human readable *description* of
+the needs -- this tool emits real sphinx-needs directives (``.. comp_req::``,
+``.. feat_req::`` ...) so that the resulting ``.rst`` file can be ``include``\\ d
+into a Sphinx project and is picked up by sphinx-needs itself.
+
+Each need becomes a directive whose name is the need ``type``. The need ``title``
+is placed on the directive line, every other (non internal) attribute is rendered
+as a directive option (``:id:``, ``:status:``, ...) and the ``content`` is
+rendered as the directive body. Needs are grouped by their ``type`` and sorted by
+``id`` so the output is stable and diff friendly.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Attributes that are not rendered as directive options because they are handled
+# specially or are internal sphinx-needs bookkeeping.
+#   * ``type``      -> becomes the directive name.
+#   * ``title``     -> rendered on the directive line.
+#   * ``content``   -> rendered as the directive body.
+#   * ``type_name`` -> derived from ``type``, not a valid need option.
+#   * ``version``   -> managed by sphinx-needs itself.
+_SKIP_ATTRS: frozenset[str] = frozenset(
+    {"type", "title", "content", "type_name", "version"}
+)
+
+# Preferred ordering for the directive options; any remaining attributes are
+# appended afterwards in alphabetical order for a stable output.
+_OPTION_ORDER: list[str] = [
+    "id",
+    "status",
+    "safety",
+    "security",
+    "reqtype",
+    "tags",
+    "derived_from",
+    "satisfies",
+    "covers",
+]
+
+# Indentation used for directive options and body (aligned under the directive).
+_INDENT = "   "
+
+
+def _format_value(value: object) -> str:
+    """Render an attribute value as a single line option string."""
+    if isinstance(value, list):
+        return ", ".join(
+            str(v)  # pyright: ignore[reportUnknownArgumentType]
+            for v in value  # pyright: ignore[reportUnknownVariableType]
+        )
+    return str(value)
+
+
+def _collect_needs(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all needs across every version, sorted by id."""
+    needs: list[dict[str, Any]] = []
+    for version in data.get("versions", {}).values():
+        needs.extend(version.get("needs", {}).values())
+    return sorted(needs, key=lambda need: str(need.get("id", "")))
+
+
+def _ordered_option_keys(need: dict[str, Any]) -> list[str]:
+    """Return the attribute keys to render as options, in a stable order."""
+    keys = [k for k in need if k not in _SKIP_ATTRS]
+    preferred = [k for k in _OPTION_ORDER if k in keys]
+    remaining = sorted(k for k in keys if k not in _OPTION_ORDER)
+    return preferred + remaining
+
+
+def _render_need(need: dict[str, Any]) -> str:
+    """Render a single need as a sphinx-needs RST directive."""
+    type_ = str(need.get("type", "need"))
+    title = str(need.get("title", "")).strip()
+
+    lines: list[str] = [f".. {type_}:: {title}".rstrip()]
+
+    for key in _ordered_option_keys(need):
+        value = need[key]
+        if value in (None, "", []):
+            continue
+        lines.append(f"{_INDENT}:{key}: {_format_value(value)}")
+
+    content = str(need.get("content", "")).strip()
+    if content:
+        lines.append("")
+        lines.extend(f"{_INDENT}{line}".rstrip() for line in content.splitlines())
+
+    return "\n".join(lines)
+
+
+def render_document(data: dict[str, Any], title: str) -> str:
+    """Render the whole needs document as reStructuredText."""
+    needs = _collect_needs(data)
+
+    blocks: list[str] = [f"{title}\n{'=' * len(title)}"]
+
+    current_type = None
+    for need in sorted(
+        needs, key=lambda n: (str(n.get("type", "")), str(n.get("id", "")))
+    ):
+        type_ = str(need.get("type", "<no type>"))
+        if type_ != current_type:
+            current_type = type_
+            blocks.append(f"{type_}\n{'-' * len(type_)}")
+        blocks.append(_render_need(need))
+
+    return "\n\n".join(blocks) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render the sphinx-needs elements of a needs.json file as "
+            "reStructuredText sphinx-needs directives."
+        )
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the reStructuredText file to write.",
+    )
+    _ = parser.add_argument(
+        "--title",
+        default="Sphinx-needs elements",
+        help="Title rendered at the top of the document.",
+    )
+    _ = parser.add_argument(
+        "input",
+        type=Path,
+        help="Input needs.json file to render.",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    document = render_document(data, title=args.title)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        _ = f.write(document)
+
+    need_count = sum(
+        len(version.get("needs", {})) for version in data.get("versions", {}).values()
+    )
+    logger.info(
+        "Rendered '%s' -> '%s' (%d needs)",
+        args.input,
+        args.output,
+        need_count,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/sphinx_needs_to_trlc.py
+++ b/scripts_bazel/sphinx_needs_to_trlc.py
@@ -1,0 +1,244 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Convert the requirement sphinx-needs elements of a needs.json file into TRLC.
+
+TRLC ("Treat Requirements Like Code", https://github.com/bmw-software-engineering/trlc)
+is a requirements-only tooling. Therefore only the S-CORE requirement element
+types are converted:
+
+* ``feat_req`` -> ``ScoreReq.FeatReq`` (feature requirement)
+* ``comp_req`` -> ``ScoreReq.CompReq`` (component requirement)
+* ``aou_req``  -> ``ScoreReq.AoU``     (assumption of use)
+
+All other sphinx-needs elements are ignored.
+
+The generated ``.trlc`` data file targets the S-CORE requirements metamodel
+(package ``ScoreReq``) defined in
+https://github.com/eclipse-score/tooling/tree/main/bazel/rules/rules_score/trlc
+and must be validated together with that metamodel.
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# sphinx-needs type -> ScoreReq metamodel type.
+_TYPE_MAP: dict[str, str] = {
+    "feat_req": "FeatReq",
+    "comp_req": "CompReq",
+    "aou_req": "AoU",
+}
+
+# ScoreReq type -> the metamodel type its ``derived_from`` references, if any.
+# Only references that resolve to an emitted object of this type are rendered.
+_DERIVED_FROM_TARGET: dict[str, str] = {
+    "FeatReq": "AssumedSystemReq",
+    "CompReq": "FeatReq",
+}
+
+
+def _string_literal(value: str) -> str:
+    """Return a TRLC string literal for ``value``."""
+    text = str(value)
+    if "\n" in text:
+        if '"""' not in text:
+            return f'"""\n{text}\n"""'
+        if "'''" not in text:
+            return f"'''\n{text}\n'''"
+        return '"""\n{text}\n"""'.format(text=text.replace('"""', '\\"\\"\\"'))
+    return '"{text}"'.format(text=text.replace('"', '\\"'))
+
+
+def _asil(value: object) -> str:
+    """Map a sphinx-needs safety value to a ScoreReq.Asil enum literal."""
+    text = str(value or "").upper().replace("ASIL", "").strip(" _-")
+    if text == "B":
+        return "ScoreReq.Asil.B"
+    if text == "D":
+        return "ScoreReq.Asil.D"
+    return "ScoreReq.Asil.QM"
+
+
+def _version(need: dict[str, Any]) -> int:
+    """Return the integer version of a need, defaulting to 1."""
+    try:
+        return int(need.get("version", 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _identifier(raw: str, used: set[str]) -> str:
+    """Turn an arbitrary need id into a unique, valid TRLC identifier."""
+    candidate = re.sub(r"[^A-Za-z0-9_]", "_", str(raw))
+    if not candidate or not (candidate[0].isalpha() or candidate[0] == "_"):
+        candidate = "n_" + candidate
+    unique = candidate
+    suffix = 2
+    while unique in used:
+        unique = f"{candidate}_{suffix}"
+        suffix += 1
+    used.add(unique)
+    return unique
+
+
+def _collect_requirement_needs(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all needs whose type maps to a ScoreReq requirement, sorted."""
+    needs: list[dict[str, Any]] = []
+    for version in data.get("versions", {}).values():
+        for need in version.get("needs", {}).values():
+            if need.get("type") in _TYPE_MAP:
+                needs.append(need)
+    needs.sort(key=lambda n: (str(n.get("type", "")), str(n.get("id", ""))))
+    return needs
+
+
+def _build_id_map(needs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Map original need id -> {ident, score_type, version} for every need."""
+    id_map: dict[str, dict[str, Any]] = {}
+    used: set[str] = set()
+    for need in needs:
+        original = str(need.get("id", "need"))
+        id_map[original] = {
+            "ident": _identifier(original, used),
+            "score_type": _TYPE_MAP[need["type"]],
+            "version": _version(need),
+        }
+    return id_map
+
+
+def _render_object(need: dict[str, Any], id_map: dict[str, dict[str, Any]]) -> str:
+    """Render a single requirement need as a ScoreReq object."""
+    info = id_map[str(need.get("id"))]
+    score_type = info["score_type"]
+    description = str(need.get("content") or need.get("title") or info["ident"])
+
+    lines = [
+        "ScoreReq.{score_type} {ident} {{".format(
+            score_type=score_type, ident=info["ident"]
+        ),
+        f"    description = {_string_literal(description)}",
+        f"    version     = {_version(need)}",
+        "    safety      = {value}".format(value=_asil(need.get("safety"))),
+    ]
+
+    target_type = _DERIVED_FROM_TARGET.get(score_type)
+    if target_type:
+        refs: list[str] = []
+        for ref in need.get("derived_from") or []:  # pyright: ignore[reportUnknownVariableType]
+            ref_info = id_map.get(str(ref))
+            if ref_info and ref_info["score_type"] == target_type:
+                refs.append(
+                    "{ident} @ {version}".format(
+                        ident=ref_info["ident"], version=ref_info["version"]
+                    )
+                )
+        if refs:
+            lines.append("    derived_from = [{refs}]".format(refs=", ".join(refs)))
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def render_trlc(data: dict[str, Any], package: str) -> str:
+    """Render the requirements data file (``.trlc``)."""
+    needs = _collect_requirement_needs(data)
+    id_map = _build_id_map(needs)
+
+    blocks = [
+        f"package {package}",
+        "",
+        "import ScoreReq",
+    ]
+
+    body: list[str] = []
+    current_type = None
+    section_open = False
+    for need in needs:
+        type_ = str(need.get("type"))
+        if type_ != current_type:
+            if section_open:
+                body.append("}")
+            current_type = type_
+            body.append("")
+            body.append(f"section {_string_literal(type_)} {{")
+            section_open = True
+        obj = _render_object(need, id_map)
+        body.append("\n".join("    " + line for line in obj.splitlines()))
+    if section_open:
+        body.append("}")
+
+    blocks.append("\n".join(body))
+    return "\n".join(blocks).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert the requirement sphinx-needs elements of a needs.json file "
+            "into TRLC targeting the S-CORE requirements metamodel (ScoreReq)."
+        ),
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the TRLC data file (.trlc) to write.",
+    )
+    _ = parser.add_argument(
+        "--package",
+        default="Needs",
+        help="TRLC package name used for the generated requirements.",
+    )
+    _ = parser.add_argument(
+        "input",
+        type=Path,
+        help="Input needs.json file to convert.",
+    )
+
+    args = parser.parse_args()
+
+    package = re.sub(r"[^A-Za-z0-9_]", "_", args.package)
+    if not package or not (package[0].isalpha() or package[0] == "_"):
+        package = "Needs"
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    objects = render_trlc(data, package=package)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        _ = f.write(objects)
+
+    converted = len(_collect_requirement_needs(data))
+    logger.info(
+        "Converted '%s' -> '%s' (%d requirements, package '%s')",
+        args.input,
+        args.output,
+        converted,
+        package,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/trlc_to_sphinx_needs.py
+++ b/scripts_bazel/trlc_to_sphinx_needs.py
@@ -1,0 +1,508 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Convert TRLC requirements into a sphinx-needs ``needs.json`` file.
+
+This is the inverse of ``sphinx_needs_to_trlc.py``. It reads a TRLC data file
+written against the S-CORE requirements metamodel (package ``ScoreReq``,
+https://github.com/eclipse-score/tooling/blob/main/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl)
+and emits the corresponding requirement sphinx-needs elements.
+
+Only the S-CORE requirement object types are converted; everything else is
+ignored:
+
+* ``ScoreReq.FeatReq``          -> ``feat_req`` (feature requirement)
+* ``ScoreReq.CompReq``          -> ``comp_req`` (component requirement)
+* ``ScoreReq.AssumedSystemReq`` -> ``stkh_req`` (stakeholder requirement)
+* ``ScoreReq.AoU``              -> ``aou_req``  (assumption of use)
+
+``derived_from`` references (e.g. ``SampleSEooC.FEAT_001@1``) are rendered as
+sphinx-needs links carrying a version constraint (``FEAT_001[version==1]``).
+Several input files can be converted at once so that requirements referenced
+across packages (e.g. the feature requirements a component requirement derives
+from) end up in the same ``needs.json`` and the links resolve.
+
+The output is a ``needs.json`` document compatible with sphinx-needs and the
+S-CORE metamodel (see ``score_metamodel``).
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# ScoreReq metamodel type -> sphinx-needs type (inverse of sphinx_needs_to_trlc).
+_TYPE_MAP: dict[str, str] = {
+    "FeatReq": "feat_req",
+    "CompReq": "comp_req",
+    "AssumedSystemReq": "stkh_req",
+    "AoU": "aou_req",
+}
+
+# Human readable type names as used by sphinx-needs (``type_name``).
+_TYPE_NAME: dict[str, str] = {
+    "feat_req": "Feature Requirement",
+    "comp_req": "Component Requirement",
+    "stkh_req": "Stakeholder Requirement",
+    "aou_req": "Assumption of Use Requirement",
+}
+
+# ScoreReq.Asil enum literal -> sphinx-needs ``safety`` value.
+_ASIL_MAP: dict[str, str] = {
+    "QM": "QM",
+    "B": "ASIL_B",
+    "D": "ASIL_D",
+}
+
+
+# -----------------------------------------------------------------------------
+# Tokenizer
+# -----------------------------------------------------------------------------
+
+
+class _Token:
+    __slots__ = ("kind", "value")
+
+    def __init__(self, kind: str, value: str):
+        self.kind = kind
+        self.value = value
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Token({self.kind!r}, {self.value!r})"
+
+
+_PUNCT: dict[str, str] = {
+    "{": "LBRACE",
+    "}": "RBRACE",
+    "[": "LBRACKET",
+    "]": "RBRACKET",
+    "=": "EQUALS",
+    "@": "AT",
+    ",": "COMMA",
+}
+
+
+def _tokenize(text: str) -> list[_Token]:  # noqa: C901
+    """Turn a TRLC source string into a flat list of tokens.
+
+    Handles ``//`` line comments, ``/* */`` block comments, single and triple
+    quoted strings, integers, punctuation and (qualified) names.
+    """
+    tokens: list[_Token] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+
+        # Whitespace.
+        if c.isspace():
+            i += 1
+            continue
+
+        # Line comment.
+        if text.startswith("//", i):
+            end = text.find("\n", i)
+            i = n if end == -1 else end + 1
+            continue
+
+        # Block comment.
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+
+        # Triple quoted strings.
+        for triple in ('"""', "'''"):
+            if text.startswith(triple, i):
+                end = text.find(triple, i + 3)
+                if end == -1:
+                    raise ValueError("Unterminated triple-quoted string")
+                tokens.append(_Token("STRING", text[i + 3 : end]))
+                i = end + 3
+                break
+        else:
+            # Single quoted string.
+            if c == '"':
+                j = i + 1
+                buf: list[str] = []
+                while j < n:
+                    ch = text[j]
+                    if ch == "\\" and j + 1 < n:
+                        buf.append(text[j + 1])
+                        j += 2
+                        continue
+                    if ch == '"':
+                        break
+                    buf.append(ch)
+                    j += 1
+                if j >= n:
+                    raise ValueError("Unterminated string")
+                tokens.append(_Token("STRING", "".join(buf)))
+                i = j + 1
+                continue
+
+            # Punctuation.
+            if c in _PUNCT:
+                tokens.append(_Token(_PUNCT[c], c))
+                i += 1
+                continue
+
+            # Integer.
+            if c.isdigit():
+                j = i
+                while j < n and text[j].isdigit():
+                    j += 1
+                tokens.append(_Token("INT", text[i:j]))
+                i = j
+                continue
+
+            # Name (possibly dotted, e.g. ScoreReq.Asil.B).
+            if c.isalpha() or c == "_":
+                j = i
+                while j < n and (text[j].isalnum() or text[j] in "_."):
+                    j += 1
+                tokens.append(_Token("NAME", text[i:j]))
+                i = j
+                continue
+
+            raise ValueError(f"Unexpected character {c!r} at offset {i}")
+        # Continue outer loop after a triple-quoted string was consumed.
+    return tokens
+
+
+# -----------------------------------------------------------------------------
+# Parser
+# -----------------------------------------------------------------------------
+
+
+class _Parser:
+    """Minimal recursive-descent parser for TRLC data files."""
+
+    def __init__(self, tokens: list[_Token]):
+        self._tokens = tokens
+        self._pos = 0
+
+    def _peek(self) -> _Token | None:
+        if self._pos < len(self._tokens):
+            return self._tokens[self._pos]
+        return None
+
+    def _next(self) -> _Token:
+        tok = self._tokens[self._pos]
+        self._pos += 1
+        return tok
+
+    def parse(self) -> list[dict[str, Any]]:
+        """Parse the whole file and return a list of object dictionaries."""
+        objects: list[dict[str, Any]] = []
+        while self._peek() is not None:
+            tok = self._peek()
+            assert tok is not None
+            if tok.kind == "NAME" and tok.value == "package":
+                self._next()  # package
+                self._next()  # name
+                continue
+            if tok.kind == "NAME" and tok.value == "import":
+                self._next()  # import
+                self._next()  # name
+                continue
+            if tok.kind == "NAME" and tok.value == "section":
+                objects.extend(self._parse_section())
+                continue
+            if tok.kind == "NAME":
+                objects.append(self._parse_object())
+                continue
+            # Unknown token - skip defensively.
+            self._next()
+        return objects
+
+    def _parse_section(self) -> list[dict[str, Any]]:
+        self._next()  # section keyword
+        self._next()  # section title (string)
+        self._expect("LBRACE")
+        objects: list[dict[str, Any]] = []
+        while True:
+            tok = self._peek()
+            if tok is None:
+                raise ValueError("Unterminated section")
+            if tok.kind == "RBRACE":
+                self._next()
+                break
+            if tok.kind == "NAME" and tok.value == "section":
+                objects.extend(self._parse_section())
+                continue
+            if tok.kind == "NAME":
+                objects.append(self._parse_object())
+                continue
+            self._next()
+        return objects
+
+    def _parse_object(self) -> dict[str, Any]:
+        type_tok = self._next()  # qualified type, e.g. ScoreReq.AoU
+        name_tok = self._next()  # object identifier
+        if name_tok.kind != "NAME":
+            raise ValueError(f"Expected object name, got {name_tok}")
+        self._expect("LBRACE")
+        fields: dict[str, Any] = {}
+        while True:
+            tok = self._peek()
+            if tok is None:
+                raise ValueError("Unterminated object")
+            if tok.kind == "RBRACE":
+                self._next()
+                break
+            field_tok = self._next()
+            if field_tok.kind != "NAME":
+                raise ValueError(f"Expected field name, got {field_tok}")
+            self._expect("EQUALS")
+            fields[field_tok.value] = self._parse_value()
+        return {
+            "type": _short_type(type_tok.value),
+            "id": name_tok.value,
+            "fields": fields,
+        }
+
+    def _parse_value(self) -> Any:
+        tok = self._next()
+        if tok.kind == "STRING":
+            return _dedent(tok.value)
+        if tok.kind == "INT":
+            return int(tok.value)
+        if tok.kind == "NAME":
+            return tok.value
+        if tok.kind == "LBRACKET":
+            return self._parse_list()
+        raise ValueError(f"Unexpected value token {tok}")
+
+    def _parse_list(self) -> list[Any]:
+        items: list[Any] = []
+        while True:
+            tok = self._peek()
+            if tok is None:
+                raise ValueError("Unterminated list")
+            if tok.kind == "RBRACKET":
+                self._next()
+                break
+            if tok.kind == "COMMA":
+                self._next()
+                continue
+            item = self._next()
+            value = item.value
+            # Preserve an optional "@ <version>" suffix on references so links
+            # can later be rendered with a version constraint.
+            nxt = self._peek()
+            if nxt is not None and nxt.kind == "AT":
+                self._next()  # @
+                version = self._next()  # version int
+                value = f"{value}@{version.value}"
+            items.append(value)
+        return items
+
+    def _expect(self, kind: str) -> _Token:
+        tok = self._next()
+        if tok.kind != kind:
+            raise ValueError(f"Expected {kind}, got {tok}")
+        return tok
+
+
+def _short_type(qualified: str) -> str:
+    """Return the last segment of a (possibly qualified) type name."""
+    return qualified.rsplit(".", 1)[-1]
+
+
+def _dedent(text: str) -> str:
+    """Strip the surrounding blank lines/indentation of a block literal."""
+    if "\n" not in text:
+        return text.strip()
+    lines = text.splitlines()
+    # Drop leading/trailing empty lines kept from the triple-quote layout.
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    indents = [len(ln) - len(ln.lstrip()) for ln in lines if ln.strip()]
+    common = min(indents) if indents else 0
+    return "\n".join(ln[common:] if len(ln) >= common else ln for ln in lines)
+
+
+# -----------------------------------------------------------------------------
+# Conversion
+# -----------------------------------------------------------------------------
+
+
+def _title_from_id(need_id: str) -> str:
+    """Derive a human readable title from a requirement identifier."""
+    segment = need_id.split("__")[-1]
+    words = re.split(r"[_\s]+", segment.strip())
+    title = " ".join(word.capitalize() for word in words if word)
+    return title or need_id
+
+
+def _safety(value: Any) -> str:
+    """Map a ScoreReq.Asil enum literal to a sphinx-needs ``safety`` value."""
+    literal = _short_type(str(value or "")) if value else ""
+    return _ASIL_MAP.get(literal.upper(), "QM")
+
+
+def _link_ref(raw: str) -> str:
+    """Render a TRLC reference as a sphinx-needs link with a version constraint.
+
+    A reference like ``SampleSEooC.FEAT_001@1`` becomes ``FEAT_001[version==1]``:
+    the package qualifier is dropped (sphinx-needs ids are flat) and the
+    ``@<version>`` suffix is turned into the ``[version==N]`` constraint
+    understood by the S-CORE metamodel.
+    """
+    ref = str(raw)
+    version = ""
+    if "@" in ref:
+        ref, _, version = ref.partition("@")
+        version = version.strip()
+    target = _short_type(ref.strip())
+    if version:
+        return f"{target}[version=={version}]"
+    return target
+
+
+def _to_need(obj: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one parsed TRLC object into a sphinx-needs element."""
+    score_type = obj["type"]
+    need_type = _TYPE_MAP.get(score_type)
+    if need_type is None:
+        return None
+
+    fields = obj["fields"]
+    need_id = str(obj["id"])
+    content = str(fields.get("description", "")).strip()
+
+    need: dict[str, Any] = {
+        "id": need_id,
+        "type": need_type,
+        "type_name": _TYPE_NAME.get(need_type, need_type),
+        "title": _title_from_id(need_id),
+        "content": content,
+        "status": _short_type(str(fields.get("status", "valid"))) or "valid",
+        "safety": _safety(fields.get("safety")),
+        "security": "NO",
+        "reqtype": "Functional",
+        "version": str(fields.get("version", 1)),
+        "tags": ["requirement"],
+    }
+
+    note = fields.get("note")
+    if note:
+        need["note"] = str(note).strip()
+
+    rationale = fields.get("rationale")
+    if rationale:
+        need["rationale"] = str(rationale).strip()
+
+    derived_from = fields.get("derived_from")
+    if isinstance(derived_from, list) and derived_from:
+        need["derived_from"] = [_link_ref(ref) for ref in derived_from]
+
+    mitigates = fields.get("mitigates")
+    if mitigates:
+        need["mitigates"] = str(mitigates).strip()
+
+    return need
+
+
+def convert(texts: list[str], project: str) -> dict[str, Any]:
+    """Convert one or more TRLC source strings into a ``needs.json`` document."""
+    objects: list[dict[str, Any]] = []
+    for text in texts:
+        objects.extend(_Parser(_tokenize(text)).parse())
+
+    needs: dict[str, Any] = {}
+    for obj in objects:
+        need = _to_need(obj)
+        if need is not None:
+            needs[need["id"]] = need
+
+    created = datetime.now(UTC).isoformat()
+    version = "1.0"
+    return {
+        "created": created,
+        "current_version": version,
+        "project": project,
+        "versions": {
+            version: {
+                "created": created,
+                "creator": {"program": "trlc_to_sphinx_needs"},
+                "needs_amount": len(needs),
+                "needs": needs,
+            }
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert TRLC requirements written against the S-CORE requirements "
+            "metamodel (ScoreReq) into a sphinx-needs needs.json file."
+        ),
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the needs.json file to write.",
+    )
+    _ = parser.add_argument(
+        "--project",
+        default="Needs",
+        help="Project name recorded in the generated needs.json.",
+    )
+    _ = parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        help="Input TRLC (.trlc) files to convert.",
+    )
+
+    args = parser.parse_args()
+
+    texts: list[str] = []
+    for path in args.inputs:
+        with open(path) as f:
+            texts.append(f.read())
+
+    data = convert(texts, project=args.project)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        _ = f.write("\n")
+
+    converted = data["versions"]["1.0"]["needs_amount"]
+    logger.info(
+        "Converted %d file(s) -> '%s' (%d requirements, project '%s')",
+        len(args.inputs),
+        args.output,
+        converted,
+        args.project,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/validate_checklist.py
+++ b/scripts_bazel/validate_checklist.py
@@ -19,9 +19,29 @@ outputs (e.g. the extracted component requirements) via a ``sha256`` attribute.
 This script:
 
 1. Reads ``needs.json`` and looks up the checklist need by its id.
-2. Computes the SHA256 over the concatenated input files (sorted by path, so the
-   result is independent of the order in which Bazel passes them).
+2. Computes the SHA256 over the validated build output.
 3. Compares the computed hash with the ``sha256`` attribute of the checklist need.
+
+There are two hashing modes:
+
+* **Flat** (no ``--link-field`` given): the SHA256 is computed over the
+  concatenated input files (sorted by path, so the result is independent of the
+  order in which Bazel passes them). This pins exactly the elements contained in
+  the input files.
+* **Transitive** (one or more ``--link-field`` given): the input files only
+  define the *root* elements (e.g. the extracted feature requirements). Starting
+  from those roots, the given link fields (e.g. ``derived_from``, ``satisfies``)
+  are followed recursively through the full ``needs.json``, collecting every
+  reachable element (e.g. the stakeholder requirements a feature requirement is
+  derived from, and their parents in turn). The SHA256 is computed over the
+  canonical serialization of the whole closure. As a result the checklist also
+  goes out of date when an *upstream* dependency (such as a linked stakeholder
+  requirement) changes, not just when a root element changes.
+
+  Reachable elements whose full content does not live in ``--needs-json`` (e.g.
+  requirements or architecture imported from another repository) must be
+  supplied via ``--extra-needs-json``; otherwise they are hashed as ``<MISSING>``
+  and changes to them are not detected.
 
 On match it writes the verified hash to ``--output`` and exits ``0``. On mismatch
 (or when the need / attribute is missing) it logs the expected and actual hashes
@@ -49,11 +69,123 @@ def find_need(data: dict[str, Any], need_id: str) -> dict[str, Any] | None:
     return None
 
 
+def collect_needs(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return a flat ``{id: need}`` mapping of every need in a needs.json structure."""
+    all_needs: dict[str, dict[str, Any]] = {}
+    for version in data.get("versions", {}).values():
+        for need_id, need in version.get("needs", {}).items():
+            all_needs[need_id] = need
+    return all_needs
+
+
+def _link_targets(need: dict[str, Any], field: str) -> list[str]:
+    """Return the link targets stored under ``field`` of ``need`` as a list.
+
+    sphinx-needs may store link targets with a version constraint suffix such as
+    ``stkh_req__foo[version==1]``. The constraint is stripped so the target
+    matches the plain need id used as the key in ``needs.json``.
+    """
+    value = need.get(field)
+    if value is None:
+        return []
+    raw = value if isinstance(value, list) else [value]
+    return [_normalize_id(str(v)) for v in raw if str(v).strip()]  # pyright: ignore[reportUnknownArgumentType]
+
+
+def _normalize_id(need_id: str) -> str:
+    """Strip a trailing ``[...]`` version constraint and whitespace from ``need_id``."""
+    return need_id.split("[", 1)[0].strip()
+
+
+def compute_closure(
+    all_needs: dict[str, dict[str, Any]],
+    roots: set[str],
+    link_fields: list[str],
+) -> set[str]:
+    """Return the transitive closure of ``roots`` following ``link_fields``.
+
+    Starting from ``roots`` every link target reachable via one of the
+    ``link_fields`` is collected recursively. Missing link targets (ids that are
+    not present in ``all_needs``) are kept in the result so that a dangling link
+    still influences the hash deterministically.
+    """
+    seen: set[str] = set()
+    stack: list[str] = list(roots)
+    while stack:
+        need_id = stack.pop()
+        if need_id in seen:
+            continue
+        seen.add(need_id)
+        need = all_needs.get(need_id)
+        if need is None:
+            continue
+        for field in link_fields:
+            for target in _link_targets(need, field):
+                if target not in seen:
+                    stack.append(target)
+    return seen
+
+
 def compute_sha256(paths: list[Path]) -> str:
     """Return the SHA256 over the concatenated contents of ``paths`` (sorted)."""
     digest = hashlib.sha256()
     for path in sorted(paths, key=lambda p: p.name):
         digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _canonicalize_need(need: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``need`` with sphinx-needs back-link lists order-normalized.
+
+    sphinx-needs auto-populates the reverse-link fields (every link field has a
+    corresponding ``<field>_back``) in document-processing order, which is *not*
+    stable with respect to unrelated changes: editing an unrelated ``.rst`` file
+    can reorder the entries of a ``*_back`` list without changing its contents.
+    Because the full need dict is hashed, that spurious reordering would
+    invalidate the checklist even though nothing semantically relevant changed.
+
+    Sorting the (string) entries of every ``*_back`` list makes the serialization
+    order-independent so only genuine changes to the set of back-links affect the
+    hash. Forward link fields are author-specified and deterministic, so they are
+    left untouched.
+    """
+    normalized = dict(need)
+    for key, value in normalized.items():
+        if key.endswith("_back") and isinstance(value, list):
+            normalized[key] = sorted(  # pyright: ignore[reportUnknownArgumentType]
+                value,
+                key=lambda item: str(item),  # pyright: ignore[reportUnknownLambdaType]
+            )
+    return normalized
+
+
+def compute_closure_sha256(
+    all_needs: dict[str, dict[str, Any]],
+    ids: set[str],
+) -> str:
+    """Return the SHA256 over the canonical serialization of ``ids`` in ``all_needs``.
+
+    Needs are serialized sorted by id, each as a deterministic JSON object
+    (``sort_keys=True``). The full need dict is hashed, so any change to a
+    reachable element - including its content, attributes or links - changes the
+    result. The auto-generated ``*_back`` link lists are order-normalized first
+    (see ``_canonicalize_need``) so that unrelated edits which only reshuffle
+    those reverse links do not invalidate the hash. Ids without a matching need
+    are still mixed into the digest so that a dangling link is detected too.
+    """
+    digest = hashlib.sha256()
+    for need_id in sorted(ids):
+        digest.update(need_id.encode("utf-8"))
+        digest.update(b"\x00")
+        need = all_needs.get(need_id)
+        if need is None:
+            digest.update(b"<MISSING>")
+        else:
+            payload = json.dumps(
+                _canonicalize_need(need), sort_keys=True, ensure_ascii=False
+            )
+            digest.update(payload.encode("utf-8"))
+        digest.update(b"\x00")
     return digest.hexdigest()
 
 
@@ -82,6 +214,35 @@ def main() -> int:
         help="Path of the stamp file to write with the verified hash on success.",
     )
     _ = parser.add_argument(
+        "--link-field",
+        dest="link_fields",
+        action="append",
+        default=[],
+        metavar="FIELD",
+        help=(
+            "Link field to follow recursively from the input (root) elements when "
+            "computing the hash (e.g. 'derived_from'). May be given multiple "
+            "times. If omitted, only the input files themselves are hashed "
+            "(no transitive dependencies)."
+        ),
+    )
+    _ = parser.add_argument(
+        "--extra-needs-json",
+        dest="extra_needs_json",
+        action="append",
+        default=[],
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Additional needs.json file providing the full content of needs that "
+            "are referenced from the validated elements but are not contained in "
+            "the main --needs-json (e.g. requirements/architecture imported from "
+            "an upstream repository). Used in transitive mode to resolve and hash "
+            "such external needs; without it they are hashed as <MISSING> and "
+            "changes to them go undetected. May be given multiple times."
+        ),
+    )
+    _ = parser.add_argument(
         "inputs",
         nargs="+",
         type=Path,
@@ -104,7 +265,49 @@ def main() -> int:
 
     expected = need.get("sha256")
 
-    actual = compute_sha256(args.inputs)
+    if args.link_fields:
+        # Transitive mode: the input files define the root elements; follow the
+        # given link fields recursively through the full needs.json and hash the
+        # whole closure (roots + all reachable dependencies).
+        root_needs: dict[str, dict[str, Any]] = {}
+        for path in args.inputs:
+            with open(path) as f:
+                root_needs.update(collect_needs(json.load(f)))
+        roots = set(root_needs.keys())
+
+        # Build the authoritative content/link graph. Extra needs.json sources
+        # (e.g. an upstream repository) only fill in needs that are missing
+        # locally, so the main --needs-json keeps precedence for local content,
+        # and the extracted root elements keep precedence over both. Without the
+        # extra sources, external needs referenced by the validated elements are
+        # absent from the graph and get hashed as <MISSING>, so changes to them
+        # are invisible to the checklist.
+        all_needs: dict[str, dict[str, Any]] = {}
+        for extra_path in args.extra_needs_json:
+            with open(extra_path) as f:
+                all_needs.update(collect_needs(json.load(f)))
+        all_needs.update(collect_needs(data))
+        all_needs.update(root_needs)
+
+        closure = compute_closure(all_needs, roots, args.link_fields)
+        dependencies = closure - roots
+        logger.info(
+            "Checklist '%s': hashing %d element(s) (%d root(s) + %d "
+            "transitive dependency/ies via %s).",
+            args.checklist_id,
+            len(closure),
+            len(roots),
+            len(dependencies),
+            ", ".join(args.link_fields),
+        )
+        if dependencies:
+            logger.info(
+                "  transitive dependencies: %s",
+                ", ".join(sorted(dependencies)),
+            )
+        actual = compute_closure_sha256(all_needs, closure)
+    else:
+        actual = compute_sha256(args.inputs)
 
     if not expected:
         logger.error(

--- a/scripts_bazel/validate_checklist.py
+++ b/scripts_bazel/validate_checklist.py
@@ -1,0 +1,139 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+Validate a requirement checklist against the build output it was reviewed against.
+
+A ``req_chklst`` sphinx-needs element pins the state of one or more build
+outputs (e.g. the extracted component requirements) via a ``sha256`` attribute.
+This script:
+
+1. Reads ``needs.json`` and looks up the checklist need by its id.
+2. Computes the SHA256 over the concatenated input files (sorted by path, so the
+   result is independent of the order in which Bazel passes them).
+3. Compares the computed hash with the ``sha256`` attribute of the checklist need.
+
+On match it writes the verified hash to ``--output`` and exits ``0``. On mismatch
+(or when the need / attribute is missing) it logs the expected and actual hashes
+and exits ``1``, which fails the Bazel build.
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def find_need(data: dict[str, Any], need_id: str) -> dict[str, Any] | None:
+    """Return the need with id ``need_id`` from a needs.json structure."""
+    for version in data.get("versions", {}).values():
+        needs = version.get("needs", {})
+        if need_id in needs:
+            return needs[need_id]
+    return None
+
+
+def compute_sha256(paths: list[Path]) -> str:
+    """Return the SHA256 over the concatenated contents of ``paths`` (sorted)."""
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda p: p.name):
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a requirement checklist (req_chklst) against the SHA256 of "
+            "the build output it was reviewed against."
+        )
+    )
+    _ = parser.add_argument(
+        "--needs-json",
+        required=True,
+        type=Path,
+        help="Path of the needs.json file containing the checklist need.",
+    )
+    _ = parser.add_argument(
+        "--checklist-id",
+        required=True,
+        help="Id of the req_chklst need to validate (e.g. 'req_chklst__foo').",
+    )
+    _ = parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path of the stamp file to write with the verified hash on success.",
+    )
+    _ = parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        help="Build output files whose combined SHA256 is validated.",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.needs_json) as f:
+        data = json.load(f)
+
+    need = find_need(data, args.checklist_id)
+    if need is None:
+        logger.error(
+            "Checklist need '%s' not found in '%s'.",
+            args.checklist_id,
+            args.needs_json,
+        )
+        return 1
+
+    expected = need.get("sha256")
+    if not expected:
+        logger.error(
+            "Checklist need '%s' has no 'sha256' attribute.",
+            args.checklist_id,
+        )
+        return 1
+
+    actual = compute_sha256(args.inputs)
+
+    if expected != actual:
+        logger.error(
+            "Checklist '%s' is OUT OF DATE.\n"
+            "  expected (sha256 in need): %s\n"
+            "  actual   (build output):  %s\n"
+            "The validated target output has changed since the checklist was "
+            "last reviewed. Re-review the checklist and update its 'sha256' "
+            "attribute to '%s'.",
+            args.checklist_id,
+            expected,
+            actual,
+            actual,
+        )
+        return 1
+
+    logger.info("Checklist '%s' is up to date (sha256=%s).", args.checklist_id, actual)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    _ = args.output.write_text(actual + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts_bazel/validate_checklist.py
+++ b/scripts_bazel/validate_checklist.py
@@ -103,14 +103,20 @@ def main() -> int:
         return 1
 
     expected = need.get("sha256")
-    if not expected:
-        logger.error(
-            "Checklist need '%s' has no 'sha256' attribute.",
-            args.checklist_id,
-        )
-        return 1
 
     actual = compute_sha256(args.inputs)
+
+    if not expected:
+        logger.error(
+            "Checklist '%s' has an EMPTY 'sha256' attribute.\n"
+            "Review the target output and, if correct, pin it by setting the "
+            "checklist's 'sha256' attribute to:\n"
+            "\n"
+            "  %s\n",
+            args.checklist_id,
+            actual,
+        )
+        return 1
 
     if expected != actual:
         logger.error(

--- a/scripts_bazel/validate_checklist.py
+++ b/scripts_bazel/validate_checklist.py
@@ -12,15 +12,15 @@
 # *******************************************************************************
 
 """
-Validate a requirement checklist against the build output it was reviewed against.
+Validate an inspection record against the build output it was reviewed against.
 
-A ``req_chklst`` sphinx-needs element pins the state of one or more build
+A ``mod_insp`` sphinx-needs element pins the state of one or more build
 outputs (e.g. the extracted component requirements) via a ``sha256`` attribute.
 This script:
 
-1. Reads ``needs.json`` and looks up the checklist need by its id.
+1. Reads ``needs.json`` and looks up the inspection record by its id.
 2. Computes the SHA256 over the validated build output.
-3. Compares the computed hash with the ``sha256`` attribute of the checklist need.
+3. Compares the computed hash with the ``sha256`` attribute of the record.
 
 There are two hashing modes:
 
@@ -192,7 +192,7 @@ def compute_closure_sha256(
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Validate a requirement checklist (req_chklst) against the SHA256 of "
+            "Validate an inspection record (mod_insp) against the SHA256 of "
             "the build output it was reviewed against."
         )
     )
@@ -205,7 +205,7 @@ def main() -> int:
     _ = parser.add_argument(
         "--checklist-id",
         required=True,
-        help="Id of the req_chklst need to validate (e.g. 'req_chklst__foo').",
+        help="Id of the mod_insp need to validate (e.g. 'mod_insp__foo').",
     )
     _ = parser.add_argument(
         "--output",

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -402,6 +402,30 @@ needs_types:
       - requirement_excl_process
     parts: 3
 
+  # Requirement Checklist
+  # A reviewable checklist element that pins the state of a set of build outputs
+  # (e.g. the extracted component requirements) via a SHA256 hash. It references
+  # the checklist document (the rendered `.rst`) and the Bazel target(s) whose
+  # output is validated against `sha256`. See the `requirements_checklist`
+  # Bazel rule in `docs.bzl`.
+  req_chklst:
+    title: Requirement Checklist
+    prefix: req_chklst__
+    mandatory_options:
+      # req-Id: tool_req__docs_common_attr_status
+      status: ^(valid|draft|invalid)$
+      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
+      # this checklist was reviewed against.
+      sha256: ^[0-9a-f]{64}$
+    optional_options:
+      # Bazel target label(s) whose output is validated against `sha256`.
+      # Multiple labels may be separated by spaces or commas.
+      targets: ^.*$
+    optional_links:
+      # Link to the checklist document (the rendered `.rst` checklist file).
+      checklist: document
+    parts: 3
+
   # - Architecture -
 
   # Architecture Element
@@ -992,6 +1016,11 @@ needs_extra_links:
   covers:
     incoming: covered by
     outgoing: covers
+
+  # Requirement Checklist -> checklist document (rendered .rst)
+  checklist:
+    incoming: is checklist for
+    outgoing: checklist document
 
   # Architecture
   consists_of:

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -919,6 +919,66 @@ needs_types:
       fully_verifies: ANY
       partially_verifies: ANY
 
+  mod_ver_report:
+    title: Module Verification Report
+    prefix: mod_vrep__
+    mandatory_options:
+      safety: ^(QM|ASIL_B)$
+      security: ^(YES|NO)$
+      status: ^(valid|invalid)$
+      verification_method: ^.*$
+    optional_options:
+      requirements_coverage_percent: ^(100|[1-9]?[0-9])$
+      structural_coverage_percent: ^(100|[1-9]?[0-9])$
+      branch_coverage_percent: ^(100|[1-9]?[0-9])$
+      verdict: ^(pass|fail|open)$
+      report_version: ^.*$
+      release_baseline: ^.*$
+    mandatory_links:
+      belongs_to: mod
+    optional_links:
+      contains: ANY
+      evidence: ANY
+      covers: ANY
+      realizes: workproduct
+    tags:
+      - verification_report
+    parts: 3
+
+  # Formal inspection evidence modeled as a first-class artifact.
+  mod_insp:
+    title: Module Inspection Record
+    prefix: mod_insp__
+    mandatory_options:
+      safety: ^(QM|ASIL_B)$
+      security: ^(YES|NO)$
+      status: ^(valid|invalid)$
+      inspection_type: ^(requirements|architecture|implementation|traceability|safety_analysis|security_analysis|other)$
+      inspection_state: ^(planned|in_review|rework_required|approved)$
+      checklist_ref: ^.*$
+      reviewers: ^.*$
+    optional_options:
+      checklist_type: ^(req|arc|impl|safety|security|custom)$
+      moderator: ^.*$
+      approver: ^.*$
+      findings_total: ^[0-9]+$
+      findings_open: ^[0-9]+$
+      pr_link: ^https://github\.com/[^/]+/[^/]+/pull/\d+$
+      correction_issue: ^https://github\.com/[^/]+/[^/]+/issues/\d+$
+      inspection_date: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+    mandatory_links:
+      belongs_to: mod
+      inspects: ANY
+    optional_links:
+      contains: ANY
+      evidence: ANY
+      approved_by: role
+      supported_by: role
+    tags:
+      - inspection
+      - verification_evidence
+    parts: 3
+
   # https://eclipse-score.github.io/process_description/main/permalink.html?id=gd_temp__change_decision_record
   dec_rec:
     title: Decision Record
@@ -1052,6 +1112,14 @@ needs_extra_links:
   partially_verifies:
     incoming: partially_verified_by
     outgoing: partially_verifies
+
+  evidence:
+    incoming: evidence_for
+    outgoing: evidence
+
+  inspects:
+    incoming: inspected_by
+    outgoing: inspects
 ##############################################################
 # Graph Checks
 # The graph checks focus on the relation of the needs and their attributes.

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -939,6 +939,11 @@ needs_types:
       verdict: ^(pass|fail|open)$
       report_version: ^.*$
       release_baseline: ^.*$
+      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
+      # target outputs plus their transitive dependencies). May be left empty to
+      # let the verification report build fail and report the computed SHA256 to
+      # pin (see `validate_checklist.py`).
+      sha256: ^([0-9a-f]{64})?$
     mandatory_links:
       # req-Id: tool_req__docs_verification_report_need
       belongs_to: mod

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -402,64 +402,6 @@ needs_types:
       - requirement_excl_process
     parts: 3
 
-  # Requirement Checklist
-  # A reviewable checklist element that pins the state of a set of build outputs
-  # (e.g. the extracted component requirements) via a SHA256 hash. It references
-  # the checklist document (the rendered `.rst`) and the Bazel target(s) whose
-  # output is validated against `sha256`. By default the hash also covers the
-  # transitive sphinx-needs dependencies of those outputs (e.g. the stakeholder
-  # requirements a feature requirement is derived from), so the checklist goes
-  # out of date when an upstream element changes too. See the
-  # `requirements_checklist` Bazel rule in `docs.bzl`.
-  req_chklst:
-    title: Requirement Checklist
-    prefix: req_chklst__
-    mandatory_options:
-      # req-Id: tool_req__docs_common_attr_status
-      status: ^(valid|draft|invalid)$
-    optional_options:
-      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
-      # target outputs plus their transitive dependencies). May be left empty to
-      # let the `requirements_checklist` build fail and report the computed
-      # SHA256 to pin (see `validate_checklist.py`).
-      sha256: ^([0-9a-f]{64})?$
-      # Bazel target label(s) whose output is validated against `sha256`.
-      # Multiple labels may be separated by spaces or commas.
-      targets: ^.*$
-    optional_links:
-      # Link to the checklist document (the rendered `.rst` checklist file).
-      checklist: document
-    parts: 3
-
-  # Architecture Checklist
-  # A reviewable checklist element that pins the state of a set of build outputs
-  # (e.g. the extracted feature/component architecture) via a SHA256 hash. It
-  # references the checklist document (the rendered `.rst`) and the Bazel
-  # target(s) whose output is validated against `sha256`. By default the hash
-  # also covers the transitive sphinx-needs dependencies of those outputs (e.g.
-  # the requirements an architecture element fulfils and their parents), so the
-  # checklist goes out of date when an upstream element changes too. See the
-  # `architecture_checklist` Bazel rule in `docs.bzl`.
-  arch_chklst:
-    title: Architecture Checklist
-    prefix: arch_chklst__
-    mandatory_options:
-      # req-Id: tool_req__docs_common_attr_status
-      status: ^(valid|draft|invalid)$
-    optional_options:
-      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
-      # target outputs plus their transitive dependencies). May be left empty to
-      # let the `architecture_checklist` build fail and report the computed
-      # SHA256 to pin (see `validate_checklist.py`).
-      sha256: ^([0-9a-f]{64})?$
-      # Bazel target label(s) whose output is validated against `sha256`.
-      # Multiple labels may be separated by spaces or commas.
-      targets: ^.*$
-    optional_links:
-      # Link to the checklist document (the rendered `.rst` checklist file).
-      checklist: document
-    parts: 3
-
   # - Architecture -
 
   # Architecture Element
@@ -1025,7 +967,7 @@ needs_types:
       # req-Id: tool_req__docs_inspection_record_need
       inspection_type: ^(requirements|architecture|implementation|traceability|safety_analysis|security_analysis|other)$
       inspection_state: ^(planned|in_review|rework_required|approved)$
-      checklist_ref: ^.*$
+      checklist_template: ^.*$
       reviewers: ^.*$
     optional_options:
       checklist_type: ^(req|arc|impl|safety|security|custom)$
@@ -1036,10 +978,18 @@ needs_types:
       pr_link: ^https://github\.com/[^/]+/[^/]+/pull/\d+$
       correction_issue: ^https://github\.com/[^/]+/[^/]+/issues/\d+$
       inspection_date: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
+      # target outputs plus their transitive dependencies). May be left empty to
+      # let the checklist build fail and report the computed SHA256 to pin
+      # (see `validate_checklist.py`).
+      sha256: ^([0-9a-f]{64})?$
     mandatory_links:
       # req-Id: tool_req__docs_inspection_record_need
-      belongs_to: mod
       inspects: ANY
+      # Link to the filled checklist document (the rendered `.rst` checklist file).
+      checklist: document
+      # Link to the verified module.
+      belongs_to: mod
     optional_links:
       # req-Id: tool_req__docs_inspection_record_need
       contains: ANY
@@ -1125,7 +1075,7 @@ needs_extra_links:
     incoming: covered by
     outgoing: covers
 
-  # Requirement Checklist -> checklist document (rendered .rst)
+  # Inspection record / checklist -> checklist document (rendered .rst)
   checklist:
     incoming: is checklist for
     outgoing: checklist document

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -414,10 +414,38 @@ needs_types:
     mandatory_options:
       # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|draft|invalid)$
-      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
-      # this checklist was reviewed against.
-      sha256: ^[0-9a-f]{64}$
     optional_options:
+      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
+      # this checklist was reviewed against. May be left empty to let the
+      # `requirements_checklist` build fail and report the computed SHA256 to
+      # pin (see `validate_checklist.py`).
+      sha256: ^([0-9a-f]{64})?$
+      # Bazel target label(s) whose output is validated against `sha256`.
+      # Multiple labels may be separated by spaces or commas.
+      targets: ^.*$
+    optional_links:
+      # Link to the checklist document (the rendered `.rst` checklist file).
+      checklist: document
+    parts: 3
+
+  # Architecture Checklist
+  # A reviewable checklist element that pins the state of a set of build outputs
+  # (e.g. the extracted feature/component architecture) via a SHA256 hash. It
+  # references the checklist document (the rendered `.rst`) and the Bazel
+  # target(s) whose output is validated against `sha256`. See the
+  # `architecture_checklist` Bazel rule in `docs.bzl`.
+  arch_chklst:
+    title: Architecture Checklist
+    prefix: arch_chklst__
+    mandatory_options:
+      # req-Id: tool_req__docs_common_attr_status
+      status: ^(valid|draft|invalid)$
+    optional_options:
+      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
+      # this checklist was reviewed against. May be left empty to let the
+      # `architecture_checklist` build fail and report the computed SHA256 to
+      # pin (see `validate_checklist.py`).
+      sha256: ^([0-9a-f]{64})?$
       # Bazel target label(s) whose output is validated against `sha256`.
       # Multiple labels may be separated by spaces or commas.
       targets: ^.*$

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -406,8 +406,11 @@ needs_types:
   # A reviewable checklist element that pins the state of a set of build outputs
   # (e.g. the extracted component requirements) via a SHA256 hash. It references
   # the checklist document (the rendered `.rst`) and the Bazel target(s) whose
-  # output is validated against `sha256`. See the `requirements_checklist`
-  # Bazel rule in `docs.bzl`.
+  # output is validated against `sha256`. By default the hash also covers the
+  # transitive sphinx-needs dependencies of those outputs (e.g. the stakeholder
+  # requirements a feature requirement is derived from), so the checklist goes
+  # out of date when an upstream element changes too. See the
+  # `requirements_checklist` Bazel rule in `docs.bzl`.
   req_chklst:
     title: Requirement Checklist
     prefix: req_chklst__
@@ -415,10 +418,10 @@ needs_types:
       # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|draft|invalid)$
     optional_options:
-      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
-      # this checklist was reviewed against. May be left empty to let the
-      # `requirements_checklist` build fail and report the computed SHA256 to
-      # pin (see `validate_checklist.py`).
+      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
+      # target outputs plus their transitive dependencies). May be left empty to
+      # let the `requirements_checklist` build fail and report the computed
+      # SHA256 to pin (see `validate_checklist.py`).
       sha256: ^([0-9a-f]{64})?$
       # Bazel target label(s) whose output is validated against `sha256`.
       # Multiple labels may be separated by spaces or commas.
@@ -432,7 +435,10 @@ needs_types:
   # A reviewable checklist element that pins the state of a set of build outputs
   # (e.g. the extracted feature/component architecture) via a SHA256 hash. It
   # references the checklist document (the rendered `.rst`) and the Bazel
-  # target(s) whose output is validated against `sha256`. See the
+  # target(s) whose output is validated against `sha256`. By default the hash
+  # also covers the transitive sphinx-needs dependencies of those outputs (e.g.
+  # the requirements an architecture element fulfils and their parents), so the
+  # checklist goes out of date when an upstream element changes too. See the
   # `architecture_checklist` Bazel rule in `docs.bzl`.
   arch_chklst:
     title: Architecture Checklist
@@ -441,10 +447,10 @@ needs_types:
       # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|draft|invalid)$
     optional_options:
-      # SHA256 (64 lowercase hex chars) of the concatenated target outputs that
-      # this checklist was reviewed against. May be left empty to let the
-      # `architecture_checklist` build fail and report the computed SHA256 to
-      # pin (see `validate_checklist.py`).
+      # SHA256 (64 lowercase hex chars) of the reviewed build output (the root
+      # target outputs plus their transitive dependencies). May be left empty to
+      # let the `architecture_checklist` build fail and report the computed
+      # SHA256 to pin (see `validate_checklist.py`).
       sha256: ^([0-9a-f]{64})?$
       # Bazel target label(s) whose output is validated against `sha256`.
       # Multiple labels may be separated by spaces or commas.

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -919,13 +919,18 @@ needs_types:
       fully_verifies: ANY
       partially_verifies: ANY
 
+  # req-Id: tool_req__docs_verification_report_need
   mod_ver_report:
     title: Module Verification Report
     prefix: mod_vrep__
     mandatory_options:
+      # req-Id: tool_req__docs_common_attr_safety
       safety: ^(QM|ASIL_B)$
+      # req-Id: tool_req__docs_common_attr_security
       security: ^(YES|NO)$
+      # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|invalid)$
+      # req-Id: tool_req__docs_verification_report_need
       verification_method: ^.*$
     optional_options:
       requirements_coverage_percent: ^(100|[1-9]?[0-9])$
@@ -935,8 +940,10 @@ needs_types:
       report_version: ^.*$
       release_baseline: ^.*$
     mandatory_links:
+      # req-Id: tool_req__docs_verification_report_need
       belongs_to: mod
     optional_links:
+      # req-Id: tool_req__docs_verification_report_need
       contains: ANY
       evidence: ANY
       covers: ANY
@@ -946,13 +953,18 @@ needs_types:
     parts: 3
 
   # Formal inspection evidence modeled as a first-class artifact.
+  # req-Id: tool_req__docs_inspection_record_need
   mod_insp:
     title: Module Inspection Record
     prefix: mod_insp__
     mandatory_options:
+      # req-Id: tool_req__docs_common_attr_safety
       safety: ^(QM|ASIL_B)$
+      # req-Id: tool_req__docs_common_attr_security
       security: ^(YES|NO)$
+      # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|invalid)$
+      # req-Id: tool_req__docs_inspection_record_need
       inspection_type: ^(requirements|architecture|implementation|traceability|safety_analysis|security_analysis|other)$
       inspection_state: ^(planned|in_review|rework_required|approved)$
       checklist_ref: ^.*$
@@ -967,9 +979,11 @@ needs_types:
       correction_issue: ^https://github\.com/[^/]+/[^/]+/issues/\d+$
       inspection_date: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
     mandatory_links:
+      # req-Id: tool_req__docs_inspection_record_need
       belongs_to: mod
       inspects: ANY
     optional_links:
+      # req-Id: tool_req__docs_inspection_record_need
       contains: ANY
       evidence: ANY
       approved_by: role

--- a/src/extensions/score_metamodel/tests/rst/options/test_options_verification_evidence.rst
+++ b/src/extensions/score_metamodel/tests/rst/options/test_options_verification_evidence.rst
@@ -1,0 +1,113 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+#CHECK: check_options
+
+
+.. Base architecture and requirement objects used by verification evidence tests
+
+.. feat:: Verification Feature
+   :id: feat__verification_feature
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+
+.. comp:: Verification Component
+   :id: comp__verification_component
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+   :belongs_to: feat__verification_feature
+
+.. mod:: Verification Module
+   :id: mod__verification_module
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+   :includes: comp__verification_component
+
+.. comp_req:: Verification Requirement
+   :id: comp_req__verification__sample
+   :reqtype: Functional
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+   :content: Requirement text for verification evidence tests.
+
+
+.. Valid machine-readable verification report need
+#EXPECT-NOT[+2]: does not follow pattern
+
+.. mod_ver_report:: Verification Report Valid
+   :id: mod_vrep__verification__valid
+   :safety: ASIL_B
+   :security: YES
+   :status: valid
+   :verification_method: test_and_inspection
+   :requirements_coverage_percent: 95
+   :structural_coverage_percent: 90
+   :branch_coverage_percent: 85
+   :verdict: pass
+   :report_version: 1.0.0
+   :release_baseline: main
+   :belongs_to: mod__verification_module
+   :covers: comp_req__verification__sample
+
+
+.. Invalid verdict value in module verification report
+#EXPECT[+2]: mod_vrep__verification__bad_verdict.verdict (pending): does not follow pattern
+
+.. mod_ver_report:: Verification Report Invalid Verdict
+   :id: mod_vrep__verification__bad_verdict
+   :safety: ASIL_B
+   :security: YES
+   :status: invalid
+   :verification_method: inspection
+   :verdict: pending
+   :belongs_to: mod__verification_module
+
+
+.. Valid machine-readable inspection record need
+#EXPECT-NOT[+2]: does not follow pattern
+
+.. mod_insp:: Inspection Record Valid
+   :id: mod_insp__verification__valid
+   :safety: ASIL_B
+   :security: YES
+   :status: valid
+   :inspection_type: requirements
+   :inspection_state: approved
+   :checklist_ref: gd_chklst__req_inspection
+   :reviewers: reviewer_a,reviewer_b
+   :checklist_type: req
+   :findings_total: 1
+   :findings_open: 0
+   :inspection_date: 2026-06-24
+   :belongs_to: mod__verification_module
+   :inspects: comp_req__verification__sample
+
+
+.. Invalid inspection_state value in module inspection record
+#EXPECT[+2]: mod_insp__verification__bad_state.inspection_state (approved_late): does not follow pattern
+
+.. mod_insp:: Inspection Record Invalid State
+   :id: mod_insp__verification__bad_state
+   :safety: ASIL_B
+   :security: YES
+   :status: invalid
+   :inspection_type: architecture
+   :inspection_state: approved_late
+   :checklist_ref: gd_chklst__arch_inspection_checklist
+   :reviewers: reviewer_a
+   :belongs_to: mod__verification_module
+   :inspects: comp_req__verification__sample

--- a/src/extensions/score_metamodel/tests/rst/options/test_options_verification_evidence.rst
+++ b/src/extensions/score_metamodel/tests/rst/options/test_options_verification_evidence.rst
@@ -87,7 +87,7 @@
    :status: valid
    :inspection_type: requirements
    :inspection_state: approved
-   :checklist_ref: gd_chklst__req_inspection
+   :checklist_template: gd_chklst__req_inspection
    :reviewers: reviewer_a,reviewer_b
    :checklist_type: req
    :findings_total: 1
@@ -95,6 +95,7 @@
    :inspection_date: 2026-06-24
    :belongs_to: mod__verification_module
    :inspects: comp_req__verification__sample
+   :checklist: doc__verification__filled_checklist
 
 
 .. Invalid inspection_state value in module inspection record
@@ -107,7 +108,8 @@
    :status: invalid
    :inspection_type: architecture
    :inspection_state: approved_late
-   :checklist_ref: gd_chklst__arch_inspection_checklist
+   :checklist_template: gd_chklst__arch_inspection_checklist
    :reviewers: reviewer_a
    :belongs_to: mod__verification_module
    :inspects: comp_req__verification__sample
+   :checklist: doc__verification__filled_checklist

--- a/src/extensions/score_metamodel/tests/test_metamodel_load.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel_load.py
@@ -94,33 +94,6 @@ def test_load_metamodel_data():
         "link1": "opt1 == test",
     }
 
-
-def test_default_metamodel_contains_generic_verification_and_inspection_types():
-    """Default metamodel contains generic module verification and inspection types."""
-    result = load_metamodel_data()
-
-    needs_types = {
-        need_type["directive"]: need_type for need_type in result.needs_types
-    }
-
-    assert "mod_ver_report" in needs_types
-    assert "mod_insp" in needs_types
-
-    mod_ver_report = needs_types["mod_ver_report"]
-    assert mod_ver_report["mandatory_links_str"]["belongs_to"] == "mod"
-    assert mod_ver_report["optional_links_str"]["contains"] == "ANY"
-    assert mod_ver_report["optional_links_str"]["evidence"] == "ANY"
-    assert mod_ver_report["optional_links_str"]["covers"] == "ANY"
-
-    mod_insp = needs_types["mod_insp"]
-    assert mod_insp["mandatory_links_str"]["inspects"] == "ANY"
-    assert mod_insp["optional_links_str"]["contains"] == "ANY"
-    assert mod_insp["optional_links_str"]["evidence"] == "ANY"
-
-    assert "evidence" in result.needs_links
-    assert "inspects" in result.needs_links
-
-
 def test_metamodel_schema_json_is_valid():
     """The metamodel JSON schema file must be syntactically valid JSON."""
     schema_path = Path(__file__).resolve().parent.parent / "metamodel-schema.json"

--- a/src/extensions/score_metamodel/tests/test_metamodel_load.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel_load.py
@@ -94,6 +94,7 @@ def test_load_metamodel_data():
         "link1": "opt1 == test",
     }
 
+
 def test_metamodel_schema_json_is_valid():
     """The metamodel JSON schema file must be syntactically valid JSON."""
     schema_path = Path(__file__).resolve().parent.parent / "metamodel-schema.json"

--- a/src/extensions/score_metamodel/tests/test_metamodel_load.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel_load.py
@@ -10,6 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+import json
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -92,3 +93,37 @@ def test_load_metamodel_data():
     assert defined_graph_check["check"] == {
         "link1": "opt1 == test",
     }
+
+
+def test_default_metamodel_contains_generic_verification_and_inspection_types():
+    """Default metamodel contains generic module verification and inspection types."""
+    result = load_metamodel_data()
+
+    needs_types = {need_type["directive"]: need_type for need_type in result.needs_types}
+
+    assert "mod_ver_report" in needs_types
+    assert "mod_insp" in needs_types
+
+    mod_ver_report = needs_types["mod_ver_report"]
+    assert mod_ver_report["mandatory_links_str"]["belongs_to"] == "mod"
+    assert mod_ver_report["optional_links_str"]["contains"] == "ANY"
+    assert mod_ver_report["optional_links_str"]["evidence"] == "ANY"
+    assert mod_ver_report["optional_links_str"]["covers"] == "ANY"
+
+    mod_insp = needs_types["mod_insp"]
+    assert mod_insp["mandatory_links_str"]["inspects"] == "ANY"
+    assert mod_insp["optional_links_str"]["contains"] == "ANY"
+    assert mod_insp["optional_links_str"]["evidence"] == "ANY"
+
+    assert "evidence" in result.needs_links
+    assert "inspects" in result.needs_links
+
+
+def test_metamodel_schema_json_is_valid():
+    """The metamodel JSON schema file must be syntactically valid JSON."""
+    schema_path = Path(__file__).resolve().parent.parent / "metamodel-schema.json"
+    with open(schema_path, encoding="utf-8") as schema_file:
+        parsed = json.load(schema_file)
+
+    assert isinstance(parsed, dict)
+    assert "$schema" in parsed

--- a/src/extensions/score_metamodel/tests/test_metamodel_load.py
+++ b/src/extensions/score_metamodel/tests/test_metamodel_load.py
@@ -99,7 +99,9 @@ def test_default_metamodel_contains_generic_verification_and_inspection_types():
     """Default metamodel contains generic module verification and inspection types."""
     result = load_metamodel_data()
 
-    needs_types = {need_type["directive"]: need_type for need_type in result.needs_types}
+    needs_types = {
+        need_type["directive"]: need_type for need_type in result.needs_types
+    }
 
     assert "mod_ver_report" in needs_types
     assert "mod_insp" in needs_types


### PR DESCRIPTION
> ⚠️ **WIP — Demonstration purposes only.** This PR is a playground/proof-of-concept and is **not** intended to be merged as-is.

## What

Adds experimental Bazel rules and helper scripts around sphinx-needs to:

- Filter `needs.json` output
- Export sphinx-needs data to **Markdown**
- Export sphinx-needs data to **TRLC**

## Why

To demonstrate how requirements/needs data can be transformed into other formats (Markdown, TRLC) as part of the docs-as-code pipeline, for discussion and evaluation.

## How to use

See the newly added `README` for details on the rules and scripts and example invocations.

## Status

This is **work in progress** for demo only — APIs, naming, and structure are subject to change.