### PR TITLE
Feat: Enable project name in rendered Docs

### DIFF
--- a/src/extensions/score_layout/html_options.py
+++ b/src/extensions/score_layout/html_options.py
@@ -31,7 +31,7 @@ def return_html_theme_options(app: Sphinx) -> dict[str, Any]:
         "use_edit_page_button": True,
         "collapse_navigation": True,
         "logo": {
-            "text": "Eclipse S-CORE",
+            "text": app.config.project if app.config.project else "Eclipse S-CORE"
         },
     }
 


### PR DESCRIPTION
## 📌 Description
Project Name now shows up in the rendered Documentation instead of it always being ECLIPSE S-Core

<img width="629" height="133" alt="image" src="https://github.com/user-attachments/assets/972ec0a2-47a1-4da2-8d7e-21ae94180ed3" />

Fixes: #613 

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
