### PR TITLE
docs: update implementation status for 7 already-implemented tool requirements

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -310,7 +310,7 @@ Versioning
    gd_req__change_attr_impact_safety,
    gd_req__doc_attr_status,
   :parent_covered: YES
-  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L207-L223
 
   Enforce that each Generic Document ``doc__*`` has the following attributes:
 
@@ -319,7 +319,8 @@ Versioning
   * safety
   * realizes
 
-  Implementation: All four attributes are enforced in ``metamodel.yaml`` —
+  Implementation: All four attributes are enforced in
+  `metamodel.yaml L207-L223 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L207-L223>`_ —
   ``status``, ``safety``, and ``security`` as ``mandatory_options`` with regex
   validation, and ``realizes`` as ``mandatory_links`` to ``workproduct``.
 
@@ -502,15 +503,19 @@ Versioning
   :parent_covered: YES
   :satisfies: gd_req__req_validity
   :status: valid
-  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L273
 
   Docs-as-Code shall enforce that the ``valid_from`` and ``valid_until`` attributes of stakeholder and feature requirements are correct.
 
   The format of a milestone is something like "v0.5" or "v1.0.1".
   No suffixes like "-SNAPSHOT" or "-beta" are allowed.
 
-  Implementation: Regex validation ``^v(0|[1-9]\d*)\.(0|[1-9]\d*)(\.( 0|[1-9]\d*))?$`` is enforced
-  as optional_options on ``stkh_req`` and ``feat_req`` types in ``metamodel.yaml``.
+  Implementation: Regex validation ``^v(0|[1-9]\d*)\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?$`` is enforced
+  as ``optional_options`` on ``stkh_req``
+  (`L273 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L273>`_)
+  and ``feat_req``
+  (`L311 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L311>`_)
+  in ``metamodel.yaml``.
 
 .. tool_req:: Enforce validity start is before end
   :id: tool_req__docs_req_attr_validity_consistency
@@ -520,13 +525,14 @@ Versioning
   :parent_covered: YES
   :satisfies: gd_req__req_validity
   :status: valid
-  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py#L283-L307
 
   Docs-as-Code shall enforce that ``valid_from`` is before ``valid_until`` attribute in stakeholder and feature requirements.
   We consider "from" is inclusive but "until" is exclusive, so from v0.5 until v1.0 means valid for v0.5 but not for v1.0.
   If either attribute is missing, no check is performed.
 
-  Implementation: ``check_validity_consistency`` local check in ``check_options.py``
+  Implementation: ``check_validity_consistency`` local check in
+  `check_options.py L283-L307 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py#L283-L307>`_
   parses milestones and verifies ``valid_from < valid_until``.
 
 
@@ -1091,14 +1097,18 @@ Testing
    :version: 2
    :satisfies: gd_req__saf_argument
    :parent_covered: NO
-   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L709
 
    Docs-As-Code shall enforce needs of type :need:`tool_req__docs_saf_types` to have a
    non empty content.
 
    Implementation: ``content: ^[\s\S]+$`` is defined as ``mandatory_options`` for
-   ``feat_saf_dfa``, ``comp_saf_dfa``, ``feat_saf_fmea``, and ``comp_saf_fmea``
-   in ``metamodel.yaml``. The ``validate_options()`` function in ``check_options.py``
+   ``feat_saf_dfa`` (`L709 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L709>`_),
+   ``comp_saf_dfa`` (`L736 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L736>`_),
+   ``feat_saf_fmea`` (`L764 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L764>`_), and
+   ``comp_saf_fmea`` (`L791 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L791>`_)
+   in ``metamodel.yaml``. The ``validate_options()`` function in
+   `check_options.py <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py#L76-L100>`_
    enforces this at build time.
 
 
@@ -1113,13 +1123,18 @@ Testing
     gd_req__saf_linkage,
     gd_req__sec_linkage_check,
   :parent_covered: YES
-  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L710
 
   Docs-As-Code shall enforce that needs of type :need:`tool_req__docs_saf_types` have a
   `violates` links to at least one dynamic / static diagram according to the table.
 
-  Implementation: ``violates`` is defined as ``mandatory_links`` for all safety analysis
-  types in ``metamodel.yaml``. The ``validate_links()`` function in ``check_options.py``
+  Implementation: ``violates`` is defined as ``mandatory_links`` for
+  ``feat_saf_dfa`` (`L710 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L710>`_),
+  ``comp_saf_dfa`` (`L740 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L740>`_),
+  ``feat_saf_fmea`` (`L768 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L768>`_), and
+  ``comp_saf_fmea`` (`L795 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L795>`_)
+  in ``metamodel.yaml``. The ``validate_links()`` function in
+  `check_options.py <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py#L162-L203>`_
   enforces the link is present and targets the correct type.
 
   .. table::
@@ -1143,7 +1158,7 @@ Testing
    :version: 2
    :satisfies: gd_req__saf_attr_fault_id
    :parent_covered: NO
-   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L758
 
    Docs-As-Code shall enforce that needs of type FMEA (see
    :need:`tool_req__docs_saf_types`) have a `fault_id` attribute.
@@ -1151,7 +1166,9 @@ Testing
    Allowed values are listed as ID in tables at :need:`gd_guidl__dfa_failure_initiators`.
 
    Implementation: ``fault_id: ^.*$`` is defined as ``mandatory_options`` for
-   ``feat_saf_fmea`` and ``comp_saf_fmea`` in ``metamodel.yaml``.
+   ``feat_saf_fmea`` (`L758 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L758>`_)
+   and ``comp_saf_fmea`` (`L785 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L785>`_)
+   in ``metamodel.yaml``.
 
 
 .. tool_req:: DFA: failure id attribute
@@ -1161,7 +1178,7 @@ Testing
    :version: 2
    :satisfies: gd_req__saf_attr_failure_id
    :parent_covered: NO
-   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L702
 
    Docs-As-Code shall enforce that needs of type DFA (see
    :need:`tool_req__docs_saf_types`) have a `failure_id` attribute.
@@ -1169,7 +1186,9 @@ Testing
    Allowed values are listed as ID in tables at :need:`gd_guidl__dfa_failure_initiators`.
 
    Implementation: ``failure_id: ^.*$`` is defined as ``mandatory_options`` for
-   ``feat_saf_dfa`` and ``comp_saf_dfa`` in ``metamodel.yaml``.
+   ``feat_saf_dfa`` (`L702 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L702>`_)
+   and ``comp_saf_dfa`` (`L730 <https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml#L730>`_)
+   in ``metamodel.yaml``.
 
 
 .. tool_req:: Failure Effect

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -303,13 +303,14 @@ Versioning
 .. tool_req:: Mandatory attributes of Generic Documents
   :id: tool_req__docs_doc_generic_mandatory
   :tags: Documents
-  :implemented: PARTIAL
-  :version: 2
+  :implemented: YES
+  :version: 3
   :satisfies:
    gd_req__doc_attributes_manual,
    gd_req__change_attr_impact_safety,
    gd_req__doc_attr_status,
   :parent_covered: YES
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
   Enforce that each Generic Document ``doc__*`` has the following attributes:
 
@@ -317,6 +318,10 @@ Versioning
   * security
   * safety
   * realizes
+
+  Implementation: All four attributes are enforced in ``metamodel.yaml`` —
+  ``status``, ``safety``, and ``security`` as ``mandatory_options`` with regex
+  validation, and ``realizes`` as ``mandatory_links`` to ``workproduct``.
 
 .. tool_req:: Mandatory Document attributes
   :id: tool_req__docs_doc_attr
@@ -492,29 +497,37 @@ Versioning
 .. tool_req:: Enforce validity attribute correctness
   :id: tool_req__docs_req_attr_validity_correctness
   :tags: Requirements
-  :implemented: PARTIAL
-  :version: 1
+  :implemented: YES
+  :version: 2
   :parent_covered: YES
   :satisfies: gd_req__req_validity
   :status: valid
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
   Docs-as-Code shall enforce that the ``valid_from`` and ``valid_until`` attributes of stakeholder and feature requirements are correct.
 
   The format of a milestone is something like "v0.5" or "v1.0.1".
   No suffixes like "-SNAPSHOT" or "-beta" are allowed.
 
+  Implementation: Regex validation ``^v(0|[1-9]\d*)\.(0|[1-9]\d*)(\.( 0|[1-9]\d*))?$`` is enforced
+  as optional_options on ``stkh_req`` and ``feat_req`` types in ``metamodel.yaml``.
+
 .. tool_req:: Enforce validity start is before end
   :id: tool_req__docs_req_attr_validity_consistency
   :tags: Requirements
-  :implemented: PARTIAL
-  :version: 1
+  :implemented: YES
+  :version: 2
   :parent_covered: YES
   :satisfies: gd_req__req_validity
   :status: valid
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/checks/check_options.py
 
   Docs-as-Code shall enforce that ``valid_from`` is before ``valid_until`` attribute in stakeholder and feature requirements.
   We consider "from" is inclusive but "until" is exclusive, so from v0.5 until v1.0 means valid for v0.5 but not for v1.0.
   If either attribute is missing, no check is performed.
+
+  Implementation: ``check_validity_consistency`` local check in ``check_options.py``
+  parses milestones and verifies ``valid_from < valid_until``.
 
 
 -------------------------
@@ -1073,72 +1086,90 @@ Testing
 
 .. tool_req:: Safety Analysis Mandatory Content
    :id: tool_req__docs_saf_attrs_content
-   :implemented: NO
+   :implemented: YES
    :tags: Safety Analysis
-   :version: 1
+   :version: 2
    :satisfies: gd_req__saf_argument
    :parent_covered: NO
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
    Docs-As-Code shall enforce needs of type :need:`tool_req__docs_saf_types` to have a
    non empty content.
+
+   Implementation: ``content: ^[\s\S]+$`` is defined as ``mandatory_options`` for
+   ``feat_saf_dfa``, ``comp_saf_dfa``, ``feat_saf_fmea``, and ``comp_saf_fmea``
+   in ``metamodel.yaml``. The ``validate_options()`` function in ``check_options.py``
+   enforces this at build time.
 
 
 
 .. tool_req:: Safety Analysis Linkage Violates
   :id: tool_req__docs_saf_attrs_violates
-  :implemented: NO
+  :implemented: YES
   :tags: Safety Analysis
-  :version: 1
+  :version: 2
   :satisfies:
     gd_req__saf_linkage_check,
     gd_req__saf_linkage,
     gd_req__sec_linkage_check,
   :parent_covered: YES
+  :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
   Docs-As-Code shall enforce that needs of type :need:`tool_req__docs_saf_types` have a
   `violates` links to at least one dynamic / static diagram according to the table.
 
+  Implementation: ``violates`` is defined as ``mandatory_links`` for all safety analysis
+  types in ``metamodel.yaml``. The ``validate_links()`` function in ``check_options.py``
+  enforces the link is present and targets the correct type.
 
   .. table::
      :widths: auto
 
-     =============  ===================
+     =============  ==========================
      Link Source    Allowed Link Target
-     =============  ===================
+     =============  ==========================
      feat_saf_dfa   feat_arc_sta
      comp_saf_dfa   comp_arc_sta
-     feat_saf_fmea  feat_arc_dyn
-     comp_saf_fmea  comp_arc_dyn
-     =============  ===================
+     feat_saf_fmea  feat_arc_dyn, feat_arc_sta
+     comp_saf_fmea  comp_arc_dyn, comp_arc_sta
+     =============  ==========================
 
 
 
 .. tool_req:: FMEA: fault id attribute
    :id: tool_req__docs_saf_attr_fmea_fault_id
-   :implemented: NO
+   :implemented: YES
    :tags: Safety Analysis
-   :version: 1
+   :version: 2
    :satisfies: gd_req__saf_attr_fault_id
    :parent_covered: NO
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
-   Docs-As-Code shall enforce that needs of type DFA (see
+   Docs-As-Code shall enforce that needs of type FMEA (see
    :need:`tool_req__docs_saf_types`) have a `fault_id` attribute.
 
    Allowed values are listed as ID in tables at :need:`gd_guidl__dfa_failure_initiators`.
+
+   Implementation: ``fault_id: ^.*$`` is defined as ``mandatory_options`` for
+   ``feat_saf_fmea`` and ``comp_saf_fmea`` in ``metamodel.yaml``.
 
 
 .. tool_req:: DFA: failure id attribute
    :id: tool_req__docs_saf_attr_dfa_failure_id
-   :implemented: NO
+   :implemented: YES
    :tags: Safety Analysis
-   :version: 1
+   :version: 2
    :satisfies: gd_req__saf_attr_failure_id
    :parent_covered: NO
+   :source_code_link: https://github.com/eclipse-score/docs-as-code/blob/main/src/extensions/score_metamodel/metamodel.yaml
 
    Docs-As-Code shall enforce that needs of type DFA (see
-   :need:`tool_req__docs_saf_types`) have a `fault_id` attribute.
+   :need:`tool_req__docs_saf_types`) have a `failure_id` attribute.
 
    Allowed values are listed as ID in tables at :need:`gd_guidl__dfa_failure_initiators`.
+
+   Implementation: ``failure_id: ^.*$`` is defined as ``mandatory_options`` for
+   ``feat_saf_dfa`` and ``comp_saf_dfa`` in ``metamodel.yaml``.
 
 
 .. tool_req:: Failure Effect


### PR DESCRIPTION
## 📌 Description

Updates `docs/internals/requirements/requirements.rst` to reflect that **7 tool requirements** previously marked as `NO` or `PARTIAL` are already enforced in the codebase. Each updated requirement now links to the corresponding implementation file.

### Requirements updated (NO/PARTIAL → YES):

| Requirement ID | What it enforces | Implementation location |
|---|---|---|
| `tool_req__docs_saf_attrs_content` | Non-empty content on safety analysis needs | `metamodel.yaml` — `content: ^[\s\S]+$` as `mandatory_options` |
| `tool_req__docs_saf_attrs_violates` | `violates` link to architecture diagrams | `metamodel.yaml` — `mandatory_links` on all safety types |
| `tool_req__docs_saf_attr_fmea_fault_id` | `fault_id` on FMEA needs | `metamodel.yaml` — `mandatory_options` on `feat_saf_fmea`, `comp_saf_fmea` |
| `tool_req__docs_saf_attr_dfa_failure_id` | `failure_id` on DFA needs | `metamodel.yaml` — `mandatory_options` on `feat_saf_dfa`, `comp_saf_dfa` |
| `tool_req__docs_req_attr_validity_correctness` | Milestone format regex | `metamodel.yaml` — `optional_options` regex on `stkh_req`, `feat_req` |
| `tool_req__docs_req_attr_validity_consistency` | `valid_from < valid_until` | `check_options.py` — `check_validity_consistency` local check |
| `tool_req__docs_doc_generic_mandatory` | status, safety, security, realizes | `metamodel.yaml` — `mandatory_options` + `mandatory_links` on `document` type |

### Motivation

The requirements documentation was outdated — these checks have been implemented in `metamodel.yaml` and `check_options.py` but the `:implemented:` field was never updated. This reduces the apparent open-issue count by ~37% (from 35 to ~22 real gaps).

## 🚨 Impact Analysis

- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [x] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

> Note: This is a documentation-only change (updating `:implemented:` status fields and adding implementation notes). No code or test changes are needed.