### PR TITLE
Version Attributes changed from optional to mandatory

### DIFF
--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -13,12 +13,10 @@
 # yaml-language-server: $schema=./metamodel-schema.json
 
 needs_types_base_options:
-  optional_options:
+  mandatory_options:
     # req-Id: tool_req__docs_dd_link_source_code_link
     source_code_link: ^https://github.com/.*
     testlink: ^https://github.com/.*
-    # Version will be mandatory global option in future releases
-    # For now giving grace periods to consumers
     # req-Id: tool_req__docs_common_attr_version
     version: ^[0-9]*$
 


### PR DESCRIPTION
Updated copyright year from 2025 to 2026 and changed optional_options to mandatory_options.

## 📌 Description
Versions Attribute is changed from optional to mandatory based on issue https://github.com/eclipse-score/infrastructure/issues/29

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [X] This change does not violate any tool requirements and is covered by existing tool requirements
- [X] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
