### PR TITLE
Fix: Documentation reference markdown myst rules

### DIFF
--- a/docs/reference/bazel_macros.rst
+++ b/docs/reference/bazel_macros.rst
@@ -80,7 +80,7 @@ Minimal example (root ``BUILD``)
      )
 
   The custom ``metamodel.yaml`` must follow the same schema as the default one
-  (see :doc:`score_metamodel </internals/extensions/metamodel>`).
+  (see :doc:`score_metamodel <metamodel>`).
   You may use ``@score_docs_as_code//src/extensions/score_metamodel:metamodel_yaml``
   for extension processing.
   When ``metamodel`` is omitted the default metamodel is used unchanged.

--- a/docs/reference/bazel_macros.rst
+++ b/docs/reference/bazel_macros.rst
@@ -80,7 +80,7 @@ Minimal example (root ``BUILD``)
      )
 
   The custom ``metamodel.yaml`` must follow the same schema as the default one
-  (see :doc:`score_metamodel <metamodel>`).
+  (see :ref:`score_metamodel <metamodel>`).
   You may use ``@score_docs_as_code//src/extensions/score_metamodel:metamodel_yaml``
   for extension processing.
   When ``metamodel`` is omitted the default metamodel is used unchanged.


### PR DESCRIPTION
Hot fix branch for 4.6 that fixes myst related documentation references.


## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [ ] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
