### PR TITLE
Feat: Add `:tracking:` to dec_rec

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -251,12 +251,12 @@ def setup(app: Sphinx) -> dict[str, str | bool]:
     app.config.needs_links.update(metamodel.needs_links)
     app.config.needs_fields.update(metamodel.needs_fields)
     app.config.needs_string_links.setdefault(
-        "mitigation_issue_linker",
+        "github_issue_linker",
         {
             "regex": r"(?P<url>https://github\.com/[^/]+/(?P<repo>[^/]+)/issues/(?P<number>\d+))",
             "link_url": "{{url}}",
             "link_name": "{{repo}}#{{number}}",
-            "options": ["mitigation_issue"],
+            "options": ["mitigation_issue", "tracking"],
         },
     )
     app.config.graph_checks = metamodel.needs_graph_check

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -939,6 +939,7 @@ needs_types:
       decision: ^.*$
     optional_options:
       consequences: ^.*$
+      tracking: ^https://github\.com/[^/]+/[^/]+/issues/\d+$
     optional_links:
       affects: ANY
 


### PR DESCRIPTION
## 📌 Description
Adding :tracking: field to decision record need.
It should link to github issues and display a clickable link. 

Fixes this request from Process: https://github.com/eclipse-score/process_description/issues/744

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
