### PR TITLE
feat: metamodel target made public

### DIFF
--- a/src/extensions/score_metamodel/BUILD
+++ b/src/extensions/score_metamodel/BUILD
@@ -37,6 +37,7 @@ filegroup(
 filegroup(
     name = "metamodel_yaml",
     srcs = ["metamodel.yaml"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
Necessary for users to actually access and extend it.

