### PR TITLE
chore(ci): use central on-pr workflow

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -20,29 +20,5 @@ on:
     types: [checks_requested]
 
 jobs:
-  pre-commit:
-    name: Run pre-commit checks
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: 🛡️ Harden Runner
-        if: github.repository_owner == 'eclipse-score'
-        uses: step-security/harden-runner@v2.18.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Run pre-commit checks
-        run: pre-commit run -a
+  common:
+    uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@on-pr


### PR DESCRIPTION
Instead of running pre-commit directly, let's run the [*full blown mega clever central on-pr workflow*](https://github.com/eclipse-score/cicd-workflows/blob/on-pr/.github/workflows/on-pr.md) - which will of course validate pre-commit as well.