### PR TITLE
Msp fix test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: bazel build --lockfile_mode=error //... -- -//src/tests/...
 
       - name: Prepare bundled test report
-        if: ! cancelled()
+        if: ${{ !cancelled() }}
         # Creating tests-report directory
         # Follow Symlinks via '-L' to copy correctly
         # Copy everything inside the 'test-reports' folder
@@ -63,7 +63,9 @@ jobs:
           rsync -amL --include='*/' --include='test.xml' --include='test.log' --exclude='*' bazel-testlogs/ tests-report/
 
       - name: Upload bundled test report
-        if: always()
+        # No need to upload something that doesn't exist. 
+        # This would be skipped anyway if the step before isn't running
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tests-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           rsync -amL --include='*/' --include='test.xml' --include='test.log' --exclude='*' bazel-testlogs/ tests-report/
 
       - name: Upload bundled test report
-        # No need to upload something that doesn't exist. 
+        # No need to upload something that doesn't exist.
         # This would be skipped anyway if the step before isn't running
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## 📌 Description
Currently the test workflow on main is broken due to bad syntax. 
It won't create the `tests-repot` folder and therefore not upload anything and then the docs build fails due to the artifact being empty. 
This PR adresses the syntax error that should fix the workflow and allow for it all to work normally. 

> Tested this in my fork, and there everything worked. So I would assume the same applies to here.

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
