### PR TITLE
feat: switch link direction between feat and log_int_arc

### DIFF
--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -708,7 +708,8 @@ but for ease of traceability this is a separate one.
   .. csv-table::
      :header: "Link source", "Relation", "Link Target", "Mandatory"
 
-     feat, includes, logic_arc_int, yes
+     logic_arc_int, included_by, feat, no
+     feat, includes, logic_arc_int, no
      mod, includes, comp, yes
      comp, implements, logic_arc_int, no
      comp, belongs_to, feat, yes
@@ -718,6 +719,11 @@ but for ease of traceability this is a separate one.
      real_arc_int_op, implements, logic_arc_int_op, no
      logic_arc_int, includes, logic_arc_int_op, no
      logic_arc_int_op, included_by, logic_arc_int, yes
+
+  .. note::
+     The link direction between ``feat`` and ``logic_arc_int`` is being switched from
+     ``feat includes logic_arc_int`` to ``logic_arc_int included_by feat``. Both directions
+     are currently accepted as optional links to avoid migration problems.
 
 
 💻 Detailed Design & Code

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -702,9 +702,8 @@ but for ease of traceability this is a separate one.
   :id: tool_req__arch_linkage_safety
   :implemented: YES
   :version: 2
-  :satisfies: gd_req__arch_linkage_safety[version==1]
-:satisfies: gd_req__arch_linkage_safety
-:parent_covered: NO
+  :satisfies: gd_req__arch_linkage_safety[version==1], gd_req__arch_build_blocks_corr[version==1]
+  :parent_covered: NO
 
   .. csv-table::
      :header: "Link source", "Relation", "Link Target", "Mandatory"

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -703,7 +703,8 @@ but for ease of traceability this is a separate one.
   :implemented: YES
   :version: 2
   :satisfies: gd_req__arch_linkage_safety[version==1]
-  :parent_covered: YES
+:satisfies: gd_req__arch_linkage_safety
+:parent_covered: NO
 
   .. csv-table::
      :header: "Link source", "Relation", "Link Target", "Mandatory"

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -403,10 +403,10 @@ needs_types:
       safety: ^(QM|ASIL_B)$
       # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|invalid)$
-    mandatory_links:
-      # req-Id: tool_req__arch_linkage_safety
-      includes: logic_arc_int, logic_arc_int_op
     optional_links:
+      # req-Id: tool_req__arch_linkage_safety
+      # Old direction kept optional during migration; superseded by logic_arc_int included_by feat
+      includes: logic_arc_int, logic_arc_int_op
       uses: logic_arc_int, logic_arc_int_op
       provides: logic_arc_int, logic_arc_int_op # preparation for linking change according to DR-005
     tags:
@@ -480,6 +480,8 @@ needs_types:
       status: ^(valid|invalid)$
     optional_links:
       # req-Id: tool_req__arch_linkage_safety
+      # New direction kept optional during migration; will supersede feat includes logic_arc_int
+      included_by: feat
       includes: logic_arc_int_op
       fulfils: feat_req
     tags:

--- a/src/extensions/score_metamodel/tests/rst/architecture/architecture_tests.rst
+++ b/src/extensions/score_metamodel/tests/rst/architecture/architecture_tests.rst
@@ -77,6 +77,7 @@
    :security: YES
    :safety: ASIL_B
    :status: invalid
+   :included_by: feat__test_feature_1
 
 .. logic_arc_int_op:: Logic Operation Test 1
    :id: logic_arc_int_op__test_feature_1__test_operation_1
@@ -90,6 +91,7 @@
    :security: YES
    :safety: ASIL_B
    :status: invalid
+   :included_by: feat__test_feature_1
 
 Component 1
 ~~~~~~~~~~~


### PR DESCRIPTION
<!-- ----------------------------------------------------------------------------
  Copyright (c) 2026 Contributors to the Eclipse Foundation

  See the NOTICE file(s) distributed with this work for additional
  information regarding copyright ownership.

  This program and the accompanying materials are made available under the
  terms of the Apache License Version 2.0 which is available at
  https://www.apache.org/licenses/LICENSE-2.0

  SPDX-License-Identifier: Apache-2.0
----------------------------------------------------------------------------- -->

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
This pull request updates the requirements and metamodel to support a migration in the directionality of the link between `feat` and `logic_arc_int`. The changes ensure that both the old and new link directions are supported as optional during the transition, and update documentation and tests accordingly.

**Requirements and Metamodel Migration:**

* Updated the requirements CSV table in `requirements.rst` to add `logic_arc_int included_by feat` as an optional link and clarified that both directions are accepted during migration. Also added a note explaining the link direction switch to help with traceability and migration. [[1]](diffhunk://#diff-32a923d5275f2e54bd39bb33b2fb1efcae50563172394b63ab083e191bd3ed73L711-R712) [[2]](diffhunk://#diff-32a923d5275f2e54bd39bb33b2fb1efcae50563172394b63ab083e191bd3ed73R723-R727)
* Changed `metamodel.yaml` so that the old `includes` link is now optional, and the new `included_by` link is also optional for `logic_arc_int` during migration. Added comments to clarify the migration status of both directions. [[1]](diffhunk://#diff-0ac6046ac75bc866580d21188af43573b945253e760280edbf05da368090304bL406-L409) [[2]](diffhunk://#diff-0ac6046ac75bc866580d21188af43573b945253e760280edbf05da368090304bR483-R484)

**Test Updates:**

* Updated architecture tests in `architecture_tests.rst` to include the new `:included_by:` field for relevant `logic_arc_int` entries, ensuring tests cover the new migration path. [[1]](diffhunk://#diff-709182606296a112f57b42cee6c6d3cb91f35aa642cc8fc172921d19ae560599R80) [[2]](diffhunk://#diff-709182606296a112f57b42cee6c6d3cb91f35aa642cc8fc172921d19ae560599R94)

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
