### PR TITLE
test: extend/fix downstream compatibility tests with additional consumer repositories

### DIFF
--- a/.github/workflows/downstream_compatibility.yml
+++ b/.github/workflows/downstream_compatibility.yml
@@ -26,12 +26,18 @@ jobs:
       fail-fast: false
       matrix:
         consumer: [
+          "baselibs and remote",
+          "inc_security_crypto and remote",
+          "inc_someip_gateway and remote",
+          "infrastructure and remote",
+          "itf and remote",
+          "module_template and local",
+          "module_template and remote",
+          "persistency and remote",
           "process_description and local",
           "process_description and remote",
           "score and local",
           "score and remote",
-          "module_template and local",
-          "module_template and remote",
         ]
 
     steps:

--- a/src/tests/downstream_compatibility/test_downstream_compatibility.py
+++ b/src/tests/downstream_compatibility/test_downstream_compatibility.py
@@ -71,6 +71,22 @@ class ConsumerRepo:
 
 
 REPOS_TO_TEST: list[ConsumerRepo] = [
+    ConsumerRepo(name="baselibs"),
+    ConsumerRepo(name="inc_security_crypto"),
+    ConsumerRepo(name="inc_someip_gateway"),
+    ConsumerRepo(name="infrastructure"),
+    ConsumerRepo(name="itf"),
+    ConsumerRepo(
+        name="module_template",
+        commands=[
+            "bazel run //:ide_support",
+            "bazel run //:docs_check",
+            "bazel run //:docs",
+            "bazel build //:needs_json",
+            "bazel test //tests/...",
+        ],
+    ),
+    ConsumerRepo(name="persistency"),
     ConsumerRepo(
         name="process_description",
         commands=[
@@ -89,20 +105,6 @@ REPOS_TO_TEST: list[ConsumerRepo] = [
             "bazel build //:needs_json",
         ],
     ),
-    ConsumerRepo(
-        name="module_template",
-        commands=[
-            "bazel run //:ide_support",
-            "bazel run //:docs_check",
-            "bazel run //:docs",
-            "bazel build //:needs_json",
-            "bazel test //tests/...",
-        ],
-    ),
-    ConsumerRepo(name="infrastructure"),
-    ConsumerRepo(name="itf"),
-    ConsumerRepo(name="baselibs"),
-    ConsumerRepo(name="inc_someip_gateway"),
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A while ago we added additional downstream users. But we forgot to activate the runs. This PR adds the missing trigger and adds even more downstream users.

The goal is to provide a better downstream compatibility baseliine for required restrictions like make needextend document local