### PR TITLE
Revert "feat!: remove superflued optional link between int and int_op…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ http_file(
 bazel_dep(name = "score_process", version = "2.0.2")
 git_override(
     module_name = "score_process",
-    commit = "6f2b105fbc8a074e23606d493266240d9db0edf7",
+    commit = "b485d01cc0cb4c0c1eaaccb17f26ee7588f4ece8",
     remote = "https://github.com/eclipse-score/process_description",
 )
 

--- a/docs/internals/requirements/requirements.rst
+++ b/docs/internals/requirements/requirements.rst
@@ -702,7 +702,7 @@ but for ease of traceability this is a separate one.
   :id: tool_req__arch_linkage_safety
   :implemented: YES
   :version: 2
-  :satisfies: gd_req__arch_linkage_safety[version==1], gd_req__arch_build_blocks_corr[version==3]
+  :satisfies: gd_req__arch_linkage_safety[version==1], gd_req__arch_build_blocks_corr[version==2]
   :parent_covered: YES
 
   .. csv-table::
@@ -717,6 +717,7 @@ but for ease of traceability this is a separate one.
      comp, consists_of, comp, no
      real_arc_int_op, included_by, real_arc_int, yes
      real_arc_int_op, implements, logic_arc_int_op, no
+     logic_arc_int, includes, logic_arc_int_op, no
      logic_arc_int_op, included_by, logic_arc_int, yes
 
   .. note::

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -481,6 +481,7 @@ needs_types:
       # req-Id: tool_req__arch_linkage_safety
       # New direction kept optional during migration; will supersede feat includes logic_arc_int
       included_by: feat
+      includes: logic_arc_int_op
       fulfils: feat_req
     tags:
       - architecture_element


### PR DESCRIPTION
… (#693)"

This reverts commit bf07c96d2530bd256dfa4388b3d7dfbced941867.

docs-as-code v8 is based on process 2.0.3. The change required for #693 was not included in process 2.0.3.
