### PR TITLE
hotfix: needs.json version

### DIFF
--- a/default_conf.py.tpl
+++ b/default_conf.py.tpl
@@ -16,5 +16,6 @@
 
 project = {PROJECT}
 project_url = {PROJECT_URL}
+version = "0.0.0"
 
 extensions = ["score_sphinx_bundle"]

--- a/src/tests/docs_bzl/helpers.py
+++ b/src/tests/docs_bzl/helpers.py
@@ -153,11 +153,15 @@ def built_output(package: str, filename: str) -> Path:
     return root / "bazel-bin" / TEST_ROOT.relative_to(root) / package / filename
 
 
-def load_needs(needs_json: Path) -> dict[str, object]:
+def load_needs_json(needs_json: Path) -> dict[str, object]:
     raw_data: object = json.loads(needs_json.read_text(encoding="utf-8"))
     if not isinstance(raw_data, dict):
         raise ValueError("needs.json must be an object")
-    data = cast("dict[str, object]", raw_data)
+    return cast("dict[str, object]", raw_data)
+
+
+def load_needs(needs_json: Path) -> dict[str, object]:
+    data = load_needs_json(needs_json)
     needs: dict[str, object] = {}
     versions = data.get("versions", {})
     if not isinstance(versions, dict):

--- a/src/tests/docs_bzl/test_basic_docs.py
+++ b/src/tests/docs_bzl/test_basic_docs.py
@@ -23,7 +23,7 @@
 # *******************************************************************************
 """Public docs() smoke scenario."""
 
-from src.tests.docs_bzl.helpers import run_scenario
+from src.tests.docs_bzl.helpers import load_needs_json, run_scenario
 
 
 def test_basic_docs_builds_html():
@@ -35,4 +35,10 @@ def test_basic_docs_builds_html():
 
 
 def test_basic_docs_builds_needs_without_conf_py():
-    run_scenario("build", "basic_docs", ":needs_json")
+    result = run_scenario("build", "basic_docs", ":needs_json")
+
+    # With no docs/conf.py the generated config is used; it must set a non-empty
+    # version so sphinx-needs writes a non-empty current_version into needs.json
+    # (an empty current_version makes the file unusable for external consumers).
+    data = load_needs_json(result.artifacts["needs.json"])
+    assert data["current_version"], "current_version must be non-empty"

--- a/src/tests/docs_bzl/test_basic_docs.py
+++ b/src/tests/docs_bzl/test_basic_docs.py
@@ -11,16 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-# *******************************************************************************
-# Copyright (c) 2026 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-# *******************************************************************************
 """Public docs() smoke scenario."""
 
 from src.tests.docs_bzl.helpers import load_needs_json, run_scenario
@@ -40,5 +30,6 @@ def test_basic_docs_builds_needs_without_conf_py():
     # With no docs/conf.py the generated config is used; it must set a non-empty
     # version so sphinx-needs writes a non-empty current_version into needs.json
     # (an empty current_version makes the file unusable for external consumers).
+    assert result.artifacts is not None, f"expected artifacts: {result}"
     data = load_needs_json(result.artifacts["needs.json"])
     assert data["current_version"], "current_version must be non-empty"


### PR DESCRIPTION
Without some version specified in conf.py, it is an empty string and that breaks things.
