### PR TITLE
fix: avoid host Git discovery in Bazel sandboxes

### DIFF
--- a/src/helper_lib/__init__.py
+++ b/src/helper_lib/__init__.py
@@ -59,6 +59,13 @@ def find_git_root() -> Path | None:
     start_path = find_ws_root()
     if start_path is None:
         start_path = Path.cwd()
+        if "execroot" in start_path.resolve().parts:
+            # Build actions do not receive BUILD_WORKSPACE_DIRECTORY. Their
+            # working directory is below Bazel's execroot, so walking parents
+            # can escape the sandbox and find an unrelated host Git worktree.
+            # Treat this as no worktree instead; bazel run uses the explicit
+            # workspace directory and never takes this fallback path.
+            return None
     git_root = Path(start_path).resolve()
     while not (git_root / ".git").exists():
         git_root = git_root.parent

--- a/src/helper_lib/test_helper_lib.py
+++ b/src/helper_lib/test_helper_lib.py
@@ -20,6 +20,7 @@ import pytest
 
 from src.helper_lib import (
     config_setdefault,
+    find_git_root,
     get_current_git_hash,
     get_github_repo_info,
     get_runfiles_dir,
@@ -80,6 +81,19 @@ def git_repo(temp_dir: Path) -> Path:
         check=True,
     )
     return git_dir
+
+
+def test_find_git_root_ignores_bazel_sandbox_ancestor_git_repo(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sandbox must not discover a Git repository outside its execroot."""
+    (temp_dir / ".git").mkdir()
+    sandbox_dir = temp_dir / "sandbox" / "linux-sandbox" / "1" / "execroot" / "_main"
+    sandbox_dir.mkdir(parents=True)
+    monkeypatch.chdir(sandbox_dir)
+    monkeypatch.delenv("BUILD_WORKSPACE_DIRECTORY", raising=False)
+
+    assert find_git_root() is None
 
 
 @pytest.fixture


### PR DESCRIPTION
Bazel sandboxed docs actions can walk out of execroot and discover a host Git worktree, causing `ubproject.toml` to be written outside the project. Stop Git-root discovery when the fallback working directory is inside `execroot`, and add a regression test. This intentionally relies on Bazel's execroot layout; it only covers the fallback path, while bazel run continues to use `BUILD_WORKSPACE_DIRECTORY`.