### PR TITLE
fix: use rev-parse for git hash lookup

### DIFF
--- a/src/helper_lib/__init__.py
+++ b/src/helper_lib/__init__.py
@@ -189,7 +189,7 @@ def get_current_git_hash(git_root: Path) -> str:
     """
     try:
         result = subprocess.run(
-            ["git", "log", "-n", "1", "--pretty=format:%H"],
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
             cwd=git_root,
             text=True,  # ✅ decode automatically
             capture_output=True,


### PR DESCRIPTION
Use a direct revision lookup rather than `git log`, which local git aliases can alter.