### PR TITLE
fix: testlinks

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -36,3 +36,6 @@ jobs:
   docs-build:
     needs: [unit-tests]
     uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@206a795e30d45de82d541206fde17abe98d2b4bf
+    with:
+      bazel-target: "//:docs"
+      tests-report-artifact: tests-report


### PR DESCRIPTION
Broken since https://github.com/eclipse-score/docs-as-code/pull/691
