### PR TITLE
chore(devcontainer): standardize SCORE devcontainer integration

### DIFF
--- a/.devcontainer/run-tool
+++ b/.devcontainer/run-tool
@@ -18,7 +18,7 @@
 # See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
 #
 # Do not modify this file. Its source of truth is managed by the
-# SCORE devcontainer version-alignment policy.
+# SCORE devcontainer standardization policy.
 
 set -euo pipefail
 

--- a/.devcontainer/run_tool.sh
+++ b/.devcontainer/run_tool.sh
@@ -16,6 +16,9 @@
 # Unified entry point for running a CLI tool by name.
 # Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
 # See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
+#
+# Do not modify this file. Its source of truth is managed by the
+# SCORE devcontainer version-alignment policy.
 
 set -euo pipefail
 

--- a/.devcontainer/run_tool.sh
+++ b/.devcontainer/run_tool.sh
@@ -16,11 +16,8 @@
 # Unified entry point for running a CLI tool by name.
 # Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
 #
-# Do not modify this file. Its source of truth is:
-# https://github.com/eclipse-score/devcontainer/blob/main/tools/run_tool.sh
-#
-# For usage and rationale, see:
-# https://github.com/eclipse-score/devcontainer/blob/main/tools/README.md
+# Do not modify this file. Its source of truth is managed by the
+# SCORE devcontainer version-alignment policy.
 
 set -euo pipefail
 
@@ -32,18 +29,12 @@ fi
 tool_name="$1"
 shift
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-repository_root="$(cd "${script_dir}/.." && pwd -P)"
-
 if { [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || [[ -d /devcontainer ]]; } &&
-    command -v "${tool_name}" >/dev/null 2>&1; then
-    exec "${tool_name}" "$@"
+  command -v "${tool_name}" >/dev/null 2>&1; then
+  exec "${tool_name}" "$@"
+elif command -v bazel >/dev/null 2>&1; then
+  exec bazel run "@score_devcontainer//tools:${tool_name}" -- "$@"
+else
+  echo "Could not run '${tool_name}': not available on PATH in a container, and bazel was not found." >&2
+  exit 127
 fi
-
-if command -v bazel >/dev/null 2>&1; then
-cd "${repository_root}"
-exec bazel run "//tools:${tool_name}" -- "$@"
-fi
-
-echo "Could not run '${tool_name}': not available on PATH in a container, and bazel was not found." >&2
-exit 127

--- a/.devcontainer/run_tool.sh
+++ b/.devcontainer/run_tool.sh
@@ -15,9 +15,7 @@
 
 # Unified entry point for running a CLI tool by name.
 # Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
-#
-# Do not modify this file. Its source of truth is managed by the
-# SCORE devcontainer version-alignment policy.
+# See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
 
 set -euo pipefail
 

--- a/.devcontainer/run_tool.sh
+++ b/.devcontainer/run_tool.sh
@@ -15,7 +15,12 @@
 
 # Unified entry point for running a CLI tool by name.
 # Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
-# See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
+#
+# Do not modify this file. Its source of truth is:
+# https://github.com/eclipse-score/devcontainer/blob/main/tools/run_tool.sh
+#
+# For usage and rationale, see:
+# https://github.com/eclipse-score/devcontainer/blob/main/tools/README.md
 
 set -euo pipefail
 
@@ -27,12 +32,18 @@ fi
 tool_name="$1"
 shift
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repository_root="$(cd "${script_dir}/.." && pwd -P)"
+
 if { [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || [[ -d /devcontainer ]]; } &&
-  command -v "${tool_name}" >/dev/null 2>&1; then
-  exec "${tool_name}" "$@"
-elif command -v bazel >/dev/null 2>&1; then
-  exec bazel run "@score_devcontainer//tools:${tool_name}" -- "$@"
-else
-  echo "Could not run '${tool_name}': not available on PATH in a container, and bazel was not found." >&2
-  exit 127
+    command -v "${tool_name}" >/dev/null 2>&1; then
+    exec "${tool_name}" "$@"
 fi
+
+if command -v bazel >/dev/null 2>&1; then
+cd "${repository_root}"
+exec bazel run "//tools:${tool_name}" -- "$@"
+fi
+
+echo "Could not run '${tool_name}': not available on PATH in a container, and bazel was not found." >&2
+exit 127

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,20 +46,20 @@ repos:
       - id: actionlint
         name: actionlint
         # Disable shellcheck and pyflakes for now, to enforce consistent behavior.
-        entry: .devcontainer/run_tool.sh actionlint -shellcheck= -pyflakes=
+        entry: .devcontainer/run-tool actionlint -shellcheck= -pyflakes=
         language: system
         require_serial: true
         types: [yaml]
         files: ^\.github/workflows/
       - id: ruff-check
         name: ruff-check
-        entry: .devcontainer/run_tool.sh ruff check --fix
+        entry: .devcontainer/run-tool ruff check --fix
         language: system
         require_serial: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: .devcontainer/run_tool.sh ruff format
+        entry: .devcontainer/run-tool ruff format
         language: system
         require_serial: true
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,20 +46,20 @@ repos:
       - id: actionlint
         name: actionlint
         # Disable shellcheck and pyflakes for now, to enforce consistent behavior.
-        entry: tools/run_tool.sh actionlint -shellcheck= -pyflakes=
+        entry: .devcontainer/run_tool.sh actionlint -shellcheck= -pyflakes=
         language: system
         require_serial: true
         types: [yaml]
         files: ^\.github/workflows/
       - id: ruff-check
         name: ruff-check
-        entry: tools/run_tool.sh ruff check --fix
+        entry: .devcontainer/run_tool.sh ruff check --fix
         language: system
         require_serial: true
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: tools/run_tool.sh ruff format
+        entry: .devcontainer/run_tool.sh ruff format
         language: system
         require_serial: true
         types: [python]


### PR DESCRIPTION
<!-- repo-policy-sync-policy: devcontainer.score-standardization -->
<!-- repo-policy-sync-head: 8b27e64723fbc5d02e248a3c653ac7ecdb282b57 -->

## Policy

**`devcontainer.score-standardization`**

Keep the SCORE devcontainer image and direct dependency on the same version,
and provide the standard SCORE tool launcher.


## Why this repository?

This repository matches this policy because `.devcontainer/Dockerfile` matches this policy's file-content condition and `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_devcontainer`.

## Changes

- `.devcontainer/run-tool`: add file
  - Provide the standard SCORE tool launcher in repositories using the SCORE devcontainer.
- `.pre-commit-config.yaml`: replace matching text
  - Point pre-commit hooks at the standard SCORE tool launcher.
- `.devcontainer/run_tool.sh`: remove file
  - Replace the previous launcher path with the standard hyphenated path.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.
