### PR TITLE
bug: edit link/button leads to 404 #706

### DIFF
--- a/src/incremental.py
+++ b/src/incremental.py
@@ -86,6 +86,11 @@ def update_module_hash(build_dir: Path, sentinel_files: list[Path]) -> None:
     (build_dir / _MODULE_HASH_FILE).write_text(_compute_hash(sentinel_files))
 
 
+def _doc_path(package_dir_env: str, source_directory: str) -> Path:
+    """Repo-relative path to the Sphinx source dir (used for the edit-on-GitHub URL)."""
+    return Path(package_dir_env) / source_directory
+
+
 def _mounted_watch_dirs(
     manifest_path: Path, ws_root: Path | None, runfiles_dir: Path | None = None
 ) -> list[str]:
@@ -196,7 +201,10 @@ if __name__ == "__main__":
         base_arguments.append(f"-A=github_user={github_user}")
         base_arguments.append(f"-A=github_repo={github_repo}")
         base_arguments.append("-A=github_version=main")
-        base_arguments.append(f"-A=doc_path={package_dir / source_directory}")
+        # doc_path must be repo-relative so the edit URL does not contain the
+        # absolute runner filesystem path (e.g. /home/runner/work/…/docs).
+        relative_doc_path = _doc_path(os.environ.get("PACKAGE_DIR", ""), source_directory)
+        base_arguments.append(f"-A=doc_path={relative_doc_path}")
 
     if os.getenv("KNOWN_GOOD_JSON"):
         base_arguments.append(f"--define=KNOWN_GOOD_JSON={get_env('KNOWN_GOOD_JSON')}")

--- a/src/incremental_dirty_build_test.py
+++ b/src/incremental_dirty_build_test.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from pyfakefs.fake_filesystem import FakeFilesystem as FFS
 
 from incremental import (
+    _doc_path,  # pyright: ignore[reportPrivateUsage] - white-box unit test
     _mounted_watch_dirs,  # pyright: ignore[reportPrivateUsage] - white-box unit test
     clean_builddir_if_stale,
     update_module_hash,
@@ -148,3 +149,26 @@ def test_mounted_watch_dirs_match_sphinx_mount_paths(tmp_path: Path) -> None:
         str(workspace / "extensions/local/docs"),
         str(runfiles_dir / "vendor+" / "docs"),
     ]
+
+
+# --- _doc_path (edit-on-GitHub URL) ------------------------------------------
+
+
+def test_doc_path_is_relative_for_root_package() -> None:
+    path = _doc_path("", "docs")
+    assert str(path) == "docs"
+    assert not path.is_absolute()
+
+
+def test_doc_path_is_relative_for_nested_package() -> None:
+    path = _doc_path("submodule", "docs")
+    assert str(path) == "submodule/docs"
+    assert not path.is_absolute()
+
+
+def test_doc_path_never_contains_absolute_runner_path() -> None:
+    # Simulates the old bug: BUILD_WORKSPACE_DIRECTORY leaking into doc_path.
+    absolute_ws = "/home/runner/work/docs-as-code/docs-as-code"
+    # _doc_path must NOT receive ws_root; only PACKAGE_DIR and source_directory.
+    path = _doc_path("", "docs")
+    assert absolute_ws not in str(path)

--- a/src/incremental_dirty_build_test.py
+++ b/src/incremental_dirty_build_test.py
@@ -167,8 +167,11 @@ def test_doc_path_is_relative_for_nested_package() -> None:
 
 
 def test_doc_path_never_contains_absolute_runner_path() -> None:
-    # Simulates the old bug: BUILD_WORKSPACE_DIRECTORY leaking into doc_path.
-    absolute_ws = "/home/runner/work/docs-as-code/docs-as-code"
-    # _doc_path must NOT receive ws_root; only PACKAGE_DIR and source_directory.
-    path = _doc_path("", "docs")
-    assert absolute_ws not in str(path)
+    # Regression test: previously doc_path was derived from BUILD_WORKSPACE_DIRECTORY.
+    absolute_ws = Path("/home/runner/work/docs-as-code/docs-as-code")
+    old_doc_path = absolute_ws / "docs"
+    assert str(absolute_ws) in str(old_doc_path)
+
+    new_doc_path = _doc_path("", "docs")
+    assert str(absolute_ws) not in str(new_doc_path)
+    assert not new_doc_path.is_absolute()


### PR DESCRIPTION
<!-- ----------------------------------------------------------------------------
  Copyright (c) 2026 Contributors to the Eclipse Foundation

  See the NOTICE file(s) distributed with this work for additional
  information regarding copyright ownership.

  This program and the accompanying materials are made available under the
  terms of the Apache License Version 2.0 which is available at
  https://www.apache.org/licenses/LICENSE-2.0

  SPDX-License-Identifier: Apache-2.0
----------------------------------------------------------------------------- -->

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
Fixes the broken Edit on GitHub link (404) by ensuring doc_path is repo-relative, not an absolute CI runner path.

Updated edit-link path handling in incremental docs build.
Added regression tests for root package, nested package, and no absolute path leakage.
Related: #706

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [X] This change does not violate any tool requirements and is covered by existing tool requirements
- [X] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [x] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
