### PR TITLE
feat: validate mandatory options cannot be empty regexes

### DIFF
--- a/src/extensions/score_metamodel/__init__.py
+++ b/src/extensions/score_metamodel/__init__.py
@@ -33,6 +33,7 @@ from src.extensions.score_metamodel.metamodel_types import (
 from src.extensions.score_metamodel.yaml_parser import (
     default_options as default_options,
     load_metamodel_data as load_metamodel_data,
+    validate_mandatory_regexes as validate_mandatory_regexes,
 )
 from src.helper_lib import config_setdefault
 
@@ -116,6 +117,16 @@ def _run_checks(app: Sphinx) -> None:
     log = CheckLogger(logger, prefix, get_reporter(app))
 
     checks_filter = parse_checks_filter(app.config.score_metamodel_checks)
+
+    for directive, option, pattern in validate_mandatory_regexes(
+        app.config.needs_types
+    ):
+        log.warning(
+            f"metamodel: `{directive}` mandatory option `{option}` "
+            f"has regex `{pattern}` that matches the empty string; "
+            f"mandatory options must not accept empty values.",
+            location="metamodel.yaml",
+        )
 
     def is_check_enabled(check: local_check_function | graph_check_function):
         return not checks_filter or check.__name__ in checks_filter

--- a/src/extensions/score_metamodel/metamodel.yaml
+++ b/src/extensions/score_metamodel/metamodel.yaml
@@ -21,7 +21,7 @@ needs_types_base_options:
     # For now giving grace periods to consumers
   mandatory_options:
     # req-Id: tool_req__docs_common_attr_version
-    version: ^[0-9]*$
+    version: ^[0-9]+$
 
     # Custom semantic validation rules
 
@@ -692,10 +692,10 @@ needs_types:
   review_header:
     title: Review Header
     mandatory_options:
-      reviewers: ^.*$
-      approvers: ^.*$
-      hash: ^.*$
-      template: ^.*$
+      reviewers: ^.+$
+      approvers: ^.+$
+      hash: ^.+$
+      template: ^.+$
     parts: 3
 
   # DFA (Dependent Failure Analysis)
@@ -789,7 +789,7 @@ needs_types:
     color: "#FFF2CC"
     mandatory_options:
       # req-Id: tool_req__docs_saf_attr_fmea_fault_id
-      fault_id: ^.*$
+      fault_id: ^.+$
       # req-Id: tool_req__docs_saf_attr_fmea_failure_effect
       failure_effect: ^.+$
       # req-Id: tool_req__docs_saf_attrs_sufficient
@@ -822,7 +822,7 @@ needs_types:
     color: "#D5E8D4"
     mandatory_options:
       # req-Id: tool_req__docs_saf_attr_fmea_fault_id
-      fault_id: ^.*$
+      fault_id: ^.+$
       # req-Id: tool_req__docs_saf_attr_fmea_failure_effect
       failure_effect: ^.+$
       # req-Id: tool_req__docs_saf_attrs_sufficient
@@ -980,7 +980,7 @@ needs_types:
       # req-Id: tool_req__docs_common_attr_status
       status: ^(valid|invalid)$
       # req-Id: tool_req__docs_verification_report_need
-      verification_method: ^.*$
+      verification_method: ^.+$
     optional_options:
       requirements_tests_completely_passed_percent: ^(100|[1-9]?[0-9])$
       line_coverage_percent: ^(100|[1-9]?[0-9])$
@@ -1005,8 +1005,8 @@ needs_types:
     title: Decision Record
     mandatory_options:
       status: ^(proposed|accepted|deprecated|rejected|superseded)$
-      context: ^.*$
-      decision: ^.*$
+      context: ^.+$
+      decision: ^.+$
     optional_options:
       consequences: ^.*$
       tracking: ^https://github\.com/[^/]+/[^/]+/issues/\d+$

--- a/src/extensions/score_metamodel/tests/test_validate_mandatory_regexes.py
+++ b/src/extensions/score_metamodel/tests/test_validate_mandatory_regexes.py
@@ -1,0 +1,186 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Tests for the metamodel lint: permissive mandatory regex detection."""
+
+from attribute_plugin import add_test_properties  # type: ignore[import-untyped]
+from score_metamodel import ScoreNeedType
+from score_metamodel.yaml_parser import validate_mandatory_regexes
+
+
+def _need_type(
+    directive: str,
+    mandatory_options: dict[str, str] | None = None,
+) -> ScoreNeedType:
+    """Build a minimal ScoreNeedType for testing."""
+    return {
+        "directive": directive,
+        "title": directive,
+        "prefix": f"{directive}__",
+        "tags": [],
+        "parts": 2,
+        "mandatory_options": mandatory_options or {},
+        "optional_options": {},
+        "mandatory_links_str": {},
+        "mandatory_links": {},
+        "optional_links_str": {},
+        "optional_links": {},
+    }
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_no_issues_for_strict_regexes():
+    """Regexes that reject the empty string are not flagged."""
+    types = [
+        _need_type("feat_saf_fmea", {"fault_id": "^.+$", "status": "^(valid)$"}),
+        _need_type("comp_saf_fmea", {"fault_id": "^.+$", "status": "^(valid)$"}),
+    ]
+    assert validate_mandatory_regexes(types) == []
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_wildcard_star():
+    """^.*$ matches the empty string and must be flagged."""
+    types = [
+        _need_type("feat_saf_fmea", {"fault_id": "^.*$"}),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 1
+    directive, option, pattern = issues[0]
+    assert directive == "feat_saf_fmea"
+    assert option == "fault_id"
+    assert pattern == "^.*$"
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_bare_wildcard():
+    """A bare .* also matches the empty string."""
+    types = [
+        _need_type("comp_saf_fmea", {"fault_id": ".*"}),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 1
+    assert issues[0][0] == "comp_saf_fmea"
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_zero_or_more_quantifier():
+    """^[0-9]*$ matches the empty string (zero digits)."""
+    types = [
+        _need_type("doc", {"version": "^[0-9]*$"}),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 1
+    assert issues[0][1] == "version"
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_empty_string_only_regex():
+    """^$ matches only the empty string — still permissive for mandatory."""
+    types = [
+        _need_type("doc", {"name": "^$"}),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 1
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_multiple_issues_in_one_type():
+    """Multiple permissive mandatory options in one type are all flagged."""
+    types = [
+        _need_type(
+            "review_header",
+            {
+                "reviewers": "^.*$",
+                "approvers": "^.*$",
+                "hash": "^.*$",
+            },
+        ),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 3
+    flagged_options = {issue[1] for issue in issues}
+    assert flagged_options == {"reviewers", "approvers", "hash"}
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_flags_across_multiple_types():
+    """Issues from different types are all collected."""
+    types = [
+        _need_type("feat_saf_fmea", {"fault_id": "^.*$"}),
+        _need_type("comp_saf_fmea", {"fault_id": "^.*$"}),
+    ]
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 2
+    directives = {issue[0] for issue in issues}
+    assert directives == {"feat_saf_fmea", "comp_saf_fmea"}
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_optional_options_not_checked():
+    """Only mandatory options are checked, not optional ones."""
+    types = [
+        _need_type(
+            "doc",
+            mandatory_options={"status": "^(valid)$"},
+        ),
+    ]
+    # This would be permissive if checked, but it's optional
+    types[0]["optional_options"] = {"author": "^.*$"}
+    assert validate_mandatory_regexes(types) == []
+
+
+@add_test_properties(
+    partially_verifies=["tool_req__docs_saf_attrs_mandatory"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+)
+def test_accepts_dict_input():
+    """The function also accepts a dict of need types."""
+    types = {
+        "feat_saf_fmea": _need_type("feat_saf_fmea", {"fault_id": "^.*$"}),
+    }
+    issues = validate_mandatory_regexes(types)
+    assert len(issues) == 1
+    assert issues[0][0] == "feat_saf_fmea"

--- a/src/extensions/score_metamodel/yaml_parser.py
+++ b/src/extensions/score_metamodel/yaml_parser.py
@@ -12,6 +12,7 @@
 # *******************************************************************************
 """Functionality related to reading in the SCORE metamodel.yaml"""
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -247,3 +248,40 @@ def load_metamodel_data(yaml_path: Path | None = None) -> MetaModelData:
         prohibited_words_checks=prohibited_words_checks,
         needs_graph_check=data.get("graph_checks", {}),
     )
+
+
+def _matches_empty_string(pattern: str) -> bool:
+    """Return True if *pattern* matches the empty string.
+
+    A mandatory attribute whose pattern accepts the empty string
+    provides no real enforcement: the attribute can be omitted or left
+    blank and still "pass" validation.
+    """
+    try:
+        return re.match(pattern, "") is not None
+    except re.error:
+        # An invalid regex is a separate error, handled by the
+        # per-need validate_options check.  Treat it as non-permissive
+        # here to avoid masking that error with a confusing message.
+        return False
+
+
+# req-Id: tool_req__docs_saf_attrs_mandatory
+def validate_mandatory_regexes(
+    needs_types: list[ScoreNeedType] | dict[str, ScoreNeedType],
+) -> list[tuple[str, str, str]]:
+    """Check that no mandatory option allow empty strings.
+
+    A mandatory attribute which can be left empty and still pass validation
+    is not really mandatory.
+    """
+    types_iter = needs_types.values() if isinstance(needs_types, dict) else needs_types
+
+    issues: list[tuple[str, str, str]] = []
+    for need_type in types_iter:
+        directive = need_type["directive"]
+        mandatory_options = need_type.get("mandatory_options", {}) or {}
+        for option, pattern in mandatory_options.items():
+            if _matches_empty_string(pattern):
+                issues.append((directive, option, pattern))
+    return issues


### PR DESCRIPTION
## 📌 Description

Addresses a gap found in doc_tool__doc_as_code version 2

## 🚨 Impact Analysis

- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [ ] Added/updated documentation for new or changed features
- [x] Added/updated tests to cover the changes
- [x] Followed project coding standards and guidelines
