### PR TITLE
test: ignore downstream Bazel lockfiles

### DIFF
--- a/src/tests/downstream_compatibility/test_downstream_compatibility.py
+++ b/src/tests/downstream_compatibility/test_downstream_compatibility.py
@@ -240,8 +240,16 @@ def _cleanup_before_cmd(cwd: Path, cmd: str) -> None:
 
 def _run_bazel_cmd(cmd: str, repo_name: str, cwd: Path) -> None:
     """Stream a bazel command to stdout; fail on non-zero exit, warn on WARNING lines."""
+
+    # Consumer repositories may configure `common --lockfile_mode=error` in
+    # their `.bazelrc`. Put the override after `bazel <command>` so the
+    # explicit command-line option takes precedence over that configuration.
+    # We do not care about broken bazel lock files.
+    args = cmd.split()
+    args.insert(2, "--lockfile_mode=ignore")
+
     process = subprocess.Popen(
-        cmd.split(),
+        args,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         universal_newlines=True,

--- a/src/tests/downstream_compatibility/test_downstream_compatibility.py
+++ b/src/tests/downstream_compatibility/test_downstream_compatibility.py
@@ -241,12 +241,12 @@ def _cleanup_before_cmd(cwd: Path, cmd: str) -> None:
 def _run_bazel_cmd(cmd: str, repo_name: str, cwd: Path) -> None:
     """Stream a bazel command to stdout; fail on non-zero exit, warn on WARNING lines."""
 
+    # We do not care about broken bazel lock files in downstream repos.
     # Consumer repositories may configure `common --lockfile_mode=error` in
     # their `.bazelrc`. Put the override after `bazel <command>` so the
     # explicit command-line option takes precedence over that configuration.
-    # We do not care about broken bazel lock files.
     args = cmd.split()
-    args.insert(2, "--lockfile_mode=ignore")
+    args.insert(2, "--lockfile_mode=off")
 
     process = subprocess.Popen(
         args,


### PR DESCRIPTION
## Summary

We don't care about lock file problems in downstream repos, however they lead to problems in our downstream tests.

- explicitly run downstream Bazel commands with `--lockfile_mode=ignore`
- prevent consumer repository `.bazelrc` settings such as `common --lockfile_mode=error` from blocking compatibility tests
