### PR TITLE
fix: treat '<error>' testcases as failed instead of passed

### DIFF
--- a/src/extensions/score_source_code_linker/tests/test_xml_parser.py
+++ b/src/extensions/score_source_code_linker/tests/test_xml_parser.py
@@ -247,6 +247,17 @@ def test_parse_testcase_result():
     ET.SubElement(tc4, "skipped", {"message": "skp"})
     assert xml_parser.parse_testcase_result(tc4) == ("skipped", "skp")
 
+    # An '<error>' (e.g. uncaught exception) must not be reported as 'passed'.
+    tc5 = ET.Element("testcase", {"name": "e"})
+    ET.SubElement(tc5, "error", {"message": "boom"})
+    assert xml_parser.parse_testcase_result(tc5) == ("failed", "boom")
+
+    # A '<failure>' takes precedence over an additional '<error>'.
+    tc6 = ET.Element("testcase", {"name": "f"})
+    ET.SubElement(tc6, "failure", {"message": "err"})
+    ET.SubElement(tc6, "error", {"message": "boom"})
+    assert xml_parser.parse_testcase_result(tc6) == ("failed", "err")
+
 
 @add_test_properties(
     partially_verifies=["tool_req__docs_test_link_testcase"],

--- a/src/extensions/score_source_code_linker/xml_parser.py
+++ b/src/extensions/score_source_code_linker/xml_parser.py
@@ -169,14 +169,20 @@ def parse_testcase_result(testcase: ET.Element) -> tuple[str, str]:
     """
     skipped = testcase.find("skipped")
     failed = testcase.find("failure")
+    # An '<error>' means the testcase did not complete, e.g. an uncaught
+    # exception in Python's unittest or a crashing binary. It must not be
+    # reported as 'passed', so it is treated like a failure.
+    errored = testcase.find("error")
     status = testcase.get("status")
     # NOTE: Special CPP case of 'disabled'
     if status is not None and status == "notrun":
         return "disabled", ""
-    if skipped is None and failed is None:
+    if skipped is None and failed is None and errored is None:
         return "passed", ""
     if failed is not None:
         return "failed", failed.get("message", "")
+    if errored is not None:
+        return "failed", errored.get("message", "")
     if skipped is not None:
         return "skipped", skipped.get("message", "")
     # TODO: Test all possible permuations of this to find if this is unreachable


### PR DESCRIPTION
`parse_testcase_result` only inspected the `<failure>` and `<skipped>` child elements of a `<testcase>`:

    if skipped is None and failed is None:
        return "passed", ""

JUnit XML also uses `<error>` for testcases that did not complete, e.g. an uncaught exception in Python's `unittest` or a crashing binary. Such a testcase has neither `<failure>` nor `<skipped>`, so it fell into the branch above and was reported as `passed`.

That is the worst possible failure mode for a verification report: a broken test silently shows up as a green `(passed)` badge next to the requirement it is supposed to verify.

Handle `<error>` explicitly and map it to `failed`, using the element's `message` attribute as the result text. An existing `<failure>` still takes precedence, so the reported message stays the assertion message when both elements are present.

<!-- ----------------------------------------------------------------------------
  Copyright (c) 2026 Contributors to the Eclipse Foundation

  See the NOTICE file(s) distributed with this work for additional
  information regarding copyright ownership.

  This program and the accompanying materials are made available under the
  terms of the Apache License Version 2.0 which is available at
  https://www.apache.org/licenses/LICENSE-2.0

  SPDX-License-Identifier: Apache-2.0
----------------------------------------------------------------------------- -->

<!--
Thank you for your contribution!
Please fill out this template to help us review your PR effectively.
-->

## 📌 Description
<!-- What does this PR change? Why is it needed? Which task it's related to? -->

## 🚨 Impact Analysis
<!-- Analyze and explain the impact of this change -->
<!-- Put an x in the boxes that apply. -->
- [ ] This change does not violate any tool requirements and is covered by existing tool requirements
- [ ] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist
<!-- Before requesting a review, please confirm that you have: -->
<!-- Put an x in the boxes that apply. -->

- [ ] Added/updated documentation for new or changed features
- [ ] Added/updated tests to cover the changes
- [ ] Followed project coding standards and guidelines

<!-- ⚠️ **Note:** Pull requests with missing tests or documentation will not be merged. -->
