### PR TITLE
test: expand downstream compatibility coverage

### DIFF
--- a/.github/workflows/downstream_compatibility.yml
+++ b/.github/workflows/downstream_compatibility.yml
@@ -31,6 +31,9 @@ jobs:
           "inc_someip_gateway and remote",
           "infrastructure and remote",
           "itf and remote",
+          "kyron and remote",
+          "lifecycle and remote",
+          "logging and remote",
           "module_template and local",
           "module_template and remote",
           "persistency and remote",
@@ -38,6 +41,7 @@ jobs:
           "process_description and remote",
           "score and local",
           "score and remote",
+          "time and remote",
         ]
 
     steps:

--- a/src/tests/downstream_compatibility/README.md
+++ b/src/tests/downstream_compatibility/README.md
@@ -85,9 +85,19 @@ Filters which repositories to test.
 
 ## Currently tested repositories
 
-- [score](https://github.com/eclipse-score/score)
-- [process_description](https://github.com/eclipse-score/process_description)
+- [baselibs](https://github.com/eclipse-score/baselibs)
+- [inc_security_crypto](https://github.com/eclipse-score/inc_security_crypto)
+- [inc_someip_gateway](https://github.com/eclipse-score/inc_someip_gateway)
+- [infrastructure](https://github.com/eclipse-score/infrastructure)
+- [itf](https://github.com/eclipse-score/itf)
+- [kyron](https://github.com/eclipse-score/kyron)
+- [lifecycle](https://github.com/eclipse-score/lifecycle)
+- [logging](https://github.com/eclipse-score/logging)
 - [module_template](https://github.com/eclipse-score/module_template)
+- [persistency](https://github.com/eclipse-score/persistency)
+- [process_description](https://github.com/eclipse-score/process_description)
+- [score](https://github.com/eclipse-score/score)
+- [time](https://github.com/eclipse-score/time)
 
 ## What Gets Tested
 

--- a/src/tests/downstream_compatibility/test_downstream_compatibility.py
+++ b/src/tests/downstream_compatibility/test_downstream_compatibility.py
@@ -86,6 +86,9 @@ REPOS_TO_TEST: list[ConsumerRepo] = [
             "bazel test //tests/...",
         ],
     ),
+    ConsumerRepo(name="kyron"),
+    ConsumerRepo(name="lifecycle"),
+    ConsumerRepo(name="logging"),
     ConsumerRepo(name="persistency"),
     ConsumerRepo(
         name="process_description",
@@ -105,6 +108,7 @@ REPOS_TO_TEST: list[ConsumerRepo] = [
             "bazel build //:needs_json",
         ],
     ),
+    ConsumerRepo(name="time"),
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add kyron, lifecycle, logging, and time to downstream compatibility tests
- include the new consumers in the CI matrix
- synchronize the consumer-test README

## Validation
- `git diff --check`
- `.venv_docs/bin/python -m pytest --collect-only -q src/tests/downstream_compatibility` (46 tests collected)
- pre-commit checks passed during commit