### PR TITLE
fix: treat basedpyright warnings as errors and clear the backlog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,9 +69,17 @@ repos:
     hooks:
       - id: BasedPyright
         name: BasedPyright
+        # BasedPyright always checks the whole project, so filenames are not
+        # passed. The file filter below still decides whether this slow hook
+        # has to run at all: only Python sources or its own configuration can
+        # change the result.
+        # Warnings are turned into a non-zero exit code by `failOnWarnings`
+        # in pyproject.toml; without it a warning-only run would exit 0 and
+        # this hook would silently pass.
         entry: bash -c 'bazel run //:ide_support && .venv_docs/bin/python3 -m basedpyright'
         language: system
         pass_filenames: false
+        files: '(\.py$|^pyproject\.toml$|^src/requirements\.(in|txt)$)'
 
   # Ensure every file has a copyright header as per the Eclipse Foundation's requirements
   # CR_CHECKER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,13 @@
 # Standard mode + some additional warnings as defined below
 typeCheckingMode = "standard"
 
+# The rules below are configured as "warning" on purpose: they are reported as
+# warnings in the IDE rather than as hard errors. They must still fail a CLI
+# run, otherwise nothing stops them from accumulating in the repository.
+# Without this, basedpyright exits 0 for a warning-only run and the pre-commit
+# hook passes.
+failOnWarnings = true
+
 # Warn if function parameters lack type annotations
 reportMissingParameterType = "warning"
 

--- a/src/extensions/score_cross_module_compatibility/__init__.py
+++ b/src/extensions/score_cross_module_compatibility/__init__.py
@@ -17,7 +17,7 @@ import os
 import re
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from sphinx.application import Sphinx
 from sphinx.util import logging
@@ -86,13 +86,16 @@ class CompatibilityReporter:
         if not isinstance(entries, list):
             return cls([], enabled_categories)
         mounts: list[ExternalMount] = []
-        for entry in entries:
-            if not isinstance(entry, dict) or not entry.get("external"):
+        for entry in cast("list[object]", entries):
+            if not isinstance(entry, dict):
                 continue
-            mount_at = entry.get("mount_at")
+            fields = cast("dict[str, object]", entry)
+            if not fields.get("external"):
+                continue
+            mount_at = fields.get("mount_at")
             if not isinstance(mount_at, str):
                 continue
-            repository = entry.get("repository", "external")
+            repository = fields.get("repository", "external")
             mounts.append(ExternalMount(mount_at.strip("/"), str(repository)))
         return cls(mounts, enabled_categories)
 

--- a/src/extensions/score_metamodel/docs/generate_metamodel_rst.py
+++ b/src/extensions/score_metamodel/docs/generate_metamodel_rst.py
@@ -62,7 +62,7 @@ def _parse_yaml(path: Path) -> Mapping[str, Any]:
 def _as_mapping(value: Any) -> Mapping[str, Any]:
     """Return *value* as a mapping or an empty mapping for missing sections."""
     if isinstance(value, Mapping):
-        return value
+        return cast(Mapping[str, Any], value)
     return {}
 
 

--- a/src/extensions/score_metamodel/tests/test_check_needs_extends.py
+++ b/src/extensions/score_metamodel/tests/test_check_needs_extends.py
@@ -14,6 +14,7 @@
 from typing import cast
 from unittest.mock import Mock
 
+import pytest
 from score_metamodel.checks import check_needs_extends
 from sphinx_needs.data import NeedsExtendType, NeedsMutable
 from sphinx_needs.need_item import NeedItem
@@ -51,7 +52,7 @@ def _needextend(target: str, *, target_is_id: bool) -> NeedsExtendType:
 
 
 def _run_check(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     all_needs: NeedsMutable,
     needextend: NeedsExtendType,
     *,
@@ -81,7 +82,7 @@ def _assert_cross_document_warning(warnings: Mock) -> None:
 
 
 def test_filter_reports_cross_document_or_match_without_changing_directive(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     local_need = _need("local-need", "local")
     remote_need = _need("remote-need", "remote")
@@ -102,7 +103,7 @@ def test_filter_reports_cross_document_or_match_without_changing_directive(
     _assert_cross_document_warning(warnings)
 
 
-def test_id_shorthand_reports_cross_document_match(monkeypatch):
+def test_id_shorthand_reports_cross_document_match(monkeypatch: pytest.MonkeyPatch):
     remote_need = _need("remote-need", "remote")
     all_needs = cast(NeedsMutable, {"remote-need": remote_need})
 

--- a/src/extensions/score_metamodel/tests/test_external_needs.py
+++ b/src/extensions/score_metamodel/tests/test_external_needs.py
@@ -24,7 +24,7 @@ import pytest
 import score_metamodel.external_needs as ext_needs
 from score_metamodel.external_needs import (
     ExternalNeedsSource,
-    _add_needs_json_file,
+    _add_needs_json_file,  # pyright: ignore[reportPrivateUsage] - white-box unit test
     add_external_docs_sources,
     add_external_needs_json,
     get_external_needs_source,

--- a/src/extensions/score_mounts/tests/test_data_mounts.py
+++ b/src/extensions/score_mounts/tests/test_data_mounts.py
@@ -16,7 +16,10 @@ from pathlib import Path
 
 import pytest
 
-from src.extensions.score_mounts import _make_mount_entry, _resolve_data_mounts
+from src.extensions.score_mounts import (
+    _make_mount_entry,  # pyright: ignore[reportPrivateUsage] - white-box unit test
+    _resolve_data_mounts,  # pyright: ignore[reportPrivateUsage] - white-box unit test
+)
 from src.extensions.score_mounts._resolver import MountsManifest, MountSpec
 
 

--- a/src/extensions/score_plantuml.py
+++ b/src/extensions/score_plantuml.py
@@ -25,8 +25,11 @@ In addition it sets common PlantUML options, like output to svg_obj.
 """
 
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
+from typing import cast
 
+from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.util import logging
 
@@ -35,7 +38,9 @@ from src.helper_lib import config_setdefault, get_runfiles_dir
 logger = logging.getLogger(__name__)
 
 
-def use_document_source_as_plantuml_cwd(app: Sphinx, doctree, docname: str) -> None:
+def use_document_source_as_plantuml_cwd(
+    app: Sphinx, doctree: nodes.document, docname: str
+) -> None:
     """Make PlantUML includes resolve from the real source-file directory.
 
     ``sphinx_mounts`` assigns mounted documents a logical docname below the
@@ -56,7 +61,10 @@ def use_document_source_as_plantuml_cwd(app: Sphinx, doctree, docname: str) -> N
     from sphinxcontrib.plantuml import plantuml
 
     del app, docname  # Required by Sphinx's event callback signature.
-    for node in doctree.findall(plantuml):
+    # ``sphinxcontrib.plantuml`` ships no type information; its nodes are
+    # ordinary docutils elements.
+    plantuml_nodes = cast("Iterator[nodes.Element]", doctree.findall(plantuml))
+    for node in plantuml_nodes:
         if node.source is None:
             continue
         source = Path(node.source)

--- a/src/extensions/score_source_code_linker/testcase_annotations.py
+++ b/src/extensions/score_source_code_linker/testcase_annotations.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from html import escape
 
 from docutils import nodes
+from sphinx.application import Sphinx
 
 # Known result values get semantic classes so the stylesheet can provide
 # readable colours for the current S-CORE light and dark themes.
@@ -110,13 +111,17 @@ def _color_existing_result_suffix(ref: nodes.reference) -> bool:
     return False
 
 
-def annotate_testcase_results(app, doctree, docname):
+def annotate_testcase_results(
+    app: Sphinx, doctree: nodes.document, docname: str
+) -> None:
     """Color rendered testcase result suffixes using the S-CORE theme palette.
 
     The handler runs after sphinx-needs' own ``doctree-resolved`` handlers.
     It therefore sees the external references generated for GitHub ``testlink``
     metadata, whose labels already contain the result.
     """
+    del app, docname  # Required by Sphinx's event callback signature.
+
     # CSS applies to the whole document, so one style block is enough even if
     # the document contains many annotated references.
     css_added = False

--- a/src/extensions/score_source_code_linker/tests/test_testcase_annotations.py
+++ b/src/extensions/score_source_code_linker/tests/test_testcase_annotations.py
@@ -14,17 +14,29 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from docutils import nodes
+from sphinx.application import Sphinx
 
 from score_pytest.attribute_plugin import add_test_properties
 from src.extensions.score_source_code_linker.testcase_annotations import (
     annotate_testcase_results,
 )
 
+# The handler only inspects the doctree; Sphinx's callback signature still
+# requires an application argument.
+_UNUSED_APP = cast(Sphinx, None)
 
-def _doctree_with_reference(*, refid=None, refuri=None, text="testcase"):
+
+def _doctree_with_reference(
+    *,
+    refid: str | None = None,
+    refuri: str | None = None,
+    text: str = "testcase",
+) -> tuple[nodes.document, nodes.reference]:
     doc = nodes.document(None, None)  # type: ignore[arg-type]
-    attrs = {}
+    attrs: dict[str, str] = {}
     if refid is not None:
         attrs["refid"] = refid
     if refuri is not None:
@@ -43,7 +55,7 @@ def test_annotates_external_github_testlink():
     """Color the result already present in an external testcase link."""
     url = "https://github.com/example/repo/blob/abc/tests/test.py#L42"
     doc, ref = _doctree_with_reference(refuri=url, text="test_requirement (passed)")
-    annotate_testcase_results(None, doc, "requirements")
+    annotate_testcase_results(_UNUSED_APP, doc, "requirements")
 
     html = ref.children[-1].astext()
     assert "score-testcase-result--passed" in html
@@ -64,7 +76,7 @@ def test_does_not_annotate_reference_without_result_suffix():
     doc, ref = _doctree_with_reference(
         refid="testcase__foo", text="Some testcase title"
     )
-    annotate_testcase_results(None, doc, "requirements")
+    annotate_testcase_results(_UNUSED_APP, doc, "requirements")
     assert len(ref.children) == 1
 
 
@@ -78,7 +90,7 @@ def test_does_not_annotate_link_without_result_suffix():
     doc, ref = _doctree_with_reference(
         refuri="https://github.com/example/repo/blob/abc/src/other.py#L1"
     )
-    annotate_testcase_results(None, doc, "requirements")
+    annotate_testcase_results(_UNUSED_APP, doc, "requirements")
     assert len(ref.children) == 1
 
 
@@ -91,7 +103,7 @@ def test_does_not_annotate_same_reference_twice():
     """Keep repeated handler invocations from duplicating an annotation."""
     url = "https://github.com/example/repo/blob/abc/tests/test.py#L42"
     doc, ref = _doctree_with_reference(refuri=url, text="testcase (passed)")
-    annotate_testcase_results(None, doc, "requirements")
-    annotate_testcase_results(None, doc, "requirements")
+    annotate_testcase_results(_UNUSED_APP, doc, "requirements")
+    annotate_testcase_results(_UNUSED_APP, doc, "requirements")
 
     assert len(ref.children) == 2

--- a/tools/module_verification_reports.py
+++ b/tools/module_verification_reports.py
@@ -40,6 +40,7 @@ import time
 import tomllib
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from pathlib import Path
+from typing import cast
 from urllib.parse import urlparse
 
 GITHUB_ORG = "eclipse-score"
@@ -172,9 +173,9 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> Profile:
     except tomllib.TOMLDecodeError as exc:
         raise ReportToolError(f"invalid profile {path}: {exc}") from exc
 
-    raw_repositories = raw_data.get("repositories")
+    raw_repositories: object = raw_data.get("repositories")
     if not isinstance(raw_repositories, list) or not all(
-        isinstance(item, dict) for item in raw_repositories
+        isinstance(item, dict) for item in cast("list[object]", raw_repositories)
     ):
         raise ReportToolError(
             f"repositories file must define repository tables: {path}"
@@ -184,7 +185,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> Profile:
     seen: set[str] = set()
     repositories.extend(
         _parse_repository_entry(entry, profile_name, path, seen)
-        for entry in raw_repositories
+        for entry in cast("list[Mapping[str, object]]", raw_repositories)
     )
 
     if not repositories:
@@ -615,15 +616,21 @@ def _flatten_needs(needs_json: Path) -> dict[str, dict[str, object]]:
         raise ReportToolError(
             f"cannot read generated needs JSON {needs_json}: {exc}"
         ) from exc
-    if not isinstance(payload, dict) or not isinstance(payload.get("versions"), dict):
+    if not isinstance(payload, dict):
+        raise ReportToolError(f"generated needs JSON has no versions map: {needs_json}")
+    versions = cast("dict[str, object]", payload).get("versions")
+    if not isinstance(versions, dict):
         raise ReportToolError(f"generated needs JSON has no versions map: {needs_json}")
     result: dict[str, dict[str, object]] = {}
-    for version in payload["versions"].values():
-        if not isinstance(version, dict) or not isinstance(version.get("needs"), dict):
+    for version in cast("dict[str, object]", versions).values():
+        if not isinstance(version, dict):
             continue
-        for need_id, need in version["needs"].items():
-            if isinstance(need_id, str) and isinstance(need, dict):
-                result[need_id] = need
+        needs = cast("dict[str, object]", version).get("needs")
+        if not isinstance(needs, dict):
+            continue
+        for need_id, need in cast("dict[str, object]", needs).items():
+            if isinstance(need, dict):
+                result[need_id] = cast("dict[str, object]", need)
     return result
 
 
@@ -634,11 +641,13 @@ def _link_ids(need: Mapping[str, object], field: str) -> list[str]:
     if not isinstance(raw, list):
         return []
     result: list[str] = []
-    for value in raw:
+    for value in cast("list[object]", raw):
         if isinstance(value, str):
             result.append(value.split("[", 1)[0])
-        elif isinstance(value, dict) and isinstance(value.get("id"), str):
-            result.append(value["id"])
+        elif isinstance(value, dict):
+            link_id = cast("dict[str, object]", value).get("id")
+            if isinstance(link_id, str):
+                result.append(link_id)
     return result
 
 
@@ -784,7 +793,7 @@ details pre{white-space:pre-wrap;word-break:break-word;background:#fff6f6;paddin
 def _write_manifest(
     output_dir: Path, profile: Profile, results: Sequence[RepositoryResult]
 ) -> None:
-    manifest = {
+    manifest: dict[str, object] = {
         "profile": profile.name,
         "repositories": [result.manifest_entry() for result in results],
     }

--- a/tools/tests/module_verification_reports_test.py
+++ b/tools/tests/module_verification_reports_test.py
@@ -265,7 +265,7 @@ def test_local_fake_downstream_build_populates_gallery_and_assets(
         )
         (build / "_static").mkdir()
         (build / "_static/site.css").write_text("body {}\n", encoding="utf-8")
-        needs = {
+        needs: dict[str, object] = {
             "versions": {
                 "1.0": {
                     "needs": {


### PR DESCRIPTION
## 📌 Description

Fixes #753.

### Root cause

`basedpyright` exits `0` when a run reports **only warnings**. Every rule in
`[tool.pyright]` is deliberately configured as `"warning"`, so the pre-commit
hook invoked the checker, saw a non-empty warning list, and still passed. That
is how 29 warnings accumulated on `main`.

Setting `failOnWarnings = true` makes any warning produce a non-zero exit code.
The rules stay declared as `"warning"` on purpose — they should still render as
warnings in the IDE rather than as hard errors. Only the CLI exit code changes,
which is exactly what gates pre-commit and CI.

### Warning fixes (29 → 0)

All of them were fixed by adding annotations or narrowing types. **No rule was
relaxed or disabled**, and no `# type: ignore` was used to paper over a real
typing problem.

- **Sphinx event handlers** — `annotate_testcase_results` and
  `use_document_source_as_plantuml_cwd` had an untyped `doctree` parameter.
  This was the highest-leverage fix: an untyped handler also made its *imports*
  partially unknown in other modules, so three warnings collapsed into one
  annotation.
- **Decoded JSON/TOML** — narrowed with the `cast("dict[str, object]", ...)`
  idiom already established in `src/tests/docs_bzl/helpers.py`, applied in the
  cross-module compatibility reporter and the module verification report tool.
- **`monkeypatch` parameters** — annotated as `pytest.MonkeyPatch`, matching
  the existing convention in `score_source_code_linker/tests`.
- **White-box test imports** — the deliberate imports of private helpers are
  marked `# pyright: ignore[reportPrivateUsage] - white-box unit test`, the
  same form already used in `src/incremental_dirty_build_test.py`.

### Hook scope

`BasedPyright` always checks the whole project, so it does not take filenames.
It previously ran on *every* commit, including docs-only and workflow-only
ones. A `files:` filter now limits this slow hook to Python sources and its own
configuration.

## 🚨 Impact Analysis

No runtime behaviour changes. The production changes are type annotations and
`cast(...)` calls, which are erased at runtime, plus one control-flow rewrite
in `_flatten_needs`/`_link_ids` that was verified to be behaviour-preserving
(see below). The remaining changes are tooling configuration.

- [x] This change does not violate any tool requirements and is covered by existing tool requirements
- [x] This change does not violate any design decisions
- [ ] Otherwise I have created a ticket for new tool qualification

## ✅ Checklist

- [x] Added/updated documentation for new or changed features
      — no user-facing documentation needed changing: `docs/` does not describe
      the pre-commit or type-checking setup, and the README's pre-commit
      section covers installation only, which is unaffected. The *why* is
      documented as comments at both changed configuration sites, since the
      non-obvious part is why warnings must fail the CLI while remaining
      warnings in the IDE.
- [ ] Added/updated tests to cover the changes
      — no new tests. Nothing changed at runtime: the edits are type
      annotations and `cast(...)` calls, which are erased at runtime. The one
      control-flow rewrite is differential-tested against the original logic
      (below) and covered by the existing suite. Enforcement comes from
      `failOnWarnings` itself, which the pre-commit run in CI already exercises.
- [x] Followed project coding standards and guidelines

## Verification

Verified against a real Bazel-provisioned venv
(`bazel run //:ide_support`, basedpyright 1.39.10, Python 3.12.12) — not an
approximation:

| | `basedpyright` result | exit code |
|---|---|---|
| `main` (before) | `0 errors, 29 warnings` | **`0`** ← the bug |
| this PR | `0 errors, 0 warnings` | `0` |
| this PR + a deliberately introduced warning | `0 errors, 2 warnings` | **`1`** ← gate works |

The middle row is the point: on `main` the checker reported 29 warnings and
still exited `0`, so the pre-commit hook passed.

Also:

- `ruff check` and `ruff format --check` → clean.
- `pytest src/extensions tools` → **283 passed**, 2 failed. Both failures
  reproduce identically on unmodified `main` (verified by checking it out) and
  are unrelated to this PR; one of them additionally needs `bazel` on `PATH`,
  which it has in CI.
- The rewrites of `_flatten_needs`, `_link_ids` and
  `CompatibilityReporter.from_manifest` were differential-tested against the
  original logic across edge cases (non-dict entries, non-`str` `mount_at`,
  malformed JSON, missing keys, non-list values) — identical output, including
  error messages.
