### PR TITLE
chore: annotate resolved source files

### DIFF
--- a/src/extensions/score_mounts/_resolver.py
+++ b/src/extensions/score_mounts/_resolver.py
@@ -167,7 +167,7 @@ def resolve_source_files(
     artifacts declared by ``docs_bundle(srcs = [...])``.
     """
     walk_dir = resolve_walk_dir(manifest, spec, ws_root, runfiles_dir)
-    resolved_files = []
+    resolved_files: list[Path] = []
     for relative_path in spec.files:
         source_file = walk_dir / relative_path
         if not source_file.is_file():


### PR DESCRIPTION
BasedPyright currently fails the pre-commit suite on the source-file resolver because its accumulator is inferred as list[Unknown]. This blocks repository checks despite the resolver already guaranteeing that it returns pathlib.Path objects.

Annotate the resolved-files accumulator as list[Path] so the static type matches the function contract and the pre-commit hook passes.