### PR TITLE
refactor: introduce wrapper for bundle declaration

### DIFF
--- a/docs.bzl
+++ b/docs.bzl
@@ -114,7 +114,7 @@ def _is_needs_json_target(label):
     """
     return str(label).rsplit(":", 1)[-1] == "needs_json"
 
-def docs_bundle(
+def _declare_docs_bundle(
     name,
     source_dir = None,
     srcs = [],
@@ -125,7 +125,12 @@ def docs_bundle(
     code_targets = [],
     visibility = None,
     **kwargs):
-    """A docs bundle, optionally composed of others.
+    """Declare the shared bundle target implementation.
+
+    This helper performs the bundle declaration used by both public entry
+    points. It deliberately contains no targets for consuming a bundle on its
+    own; those can be added to the public ``docs_bundle`` wrapper without
+    making ``docs()`` create them for the project root.
 
     Args:
       name: target name.
@@ -208,6 +213,37 @@ def docs_bundle(
         entry_doc = entry_doc,
         bundles = bundles,
         data = bundle_data,
+        visibility = visibility,
+        **kwargs
+    )
+
+def docs_bundle(
+    name,
+    source_dir = None,
+    srcs = [],
+    data = [],
+    entry_doc = "index",
+    bundles = [],
+    scan_code = [],
+    code_targets = [],
+    visibility = None,
+    **kwargs):
+    """Declare a reusable documentation bundle.
+
+    The declaration itself is delegated to the shared helper. Keeping this
+    public entry point separate gives bundle-specific consumer targets a
+    distinct home while allowing ``docs()`` to use the shared declaration for
+    the project root.
+    """
+    _declare_docs_bundle(
+        name = name,
+        source_dir = source_dir,
+        srcs = srcs,
+        data = data,
+        entry_doc = entry_doc,
+        bundles = bundles,
+        scan_code = scan_code,
+        code_targets = code_targets,
         visibility = visibility,
         **kwargs
     )
@@ -381,7 +417,7 @@ def docs(
 
     # The public bundle carries both the complete source tree and the
     # transitive source-code links of every nested bundle.
-    docs_bundle(
+    _declare_docs_bundle(
         name = "docs_bundle",
         source_dir = source_dir,
         data = data,


### PR DESCRIPTION
## Why this matters

The top-level `docs()` build called the top-level `docs_bundle()` function. So one public function was based on another public function. This makes future improvements very difficult. Instead they should rely on a common private function.

## What changed

- Move the existing declaration logic into a shared private helper.
- Keep `docs_bundle()` as the public forwarding entry point.
- Have `docs()` use the shared helper directly.
- Preserve the existing macro arguments and declaration behavior.

This is a structural preparation with no user-visible behavior change. The wrapper is intentionally retained as the extension point for future bundle-only targets.