### PR TITLE
ci: try cached workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,6 +19,7 @@ permissions:
   pull-requests: write
   pages: write
   id-token: write
+  actions: write # cleanup old caches
 
 on:
   # Runs every day at midnight UTC
@@ -37,4 +38,4 @@ on:
 
 jobs:
   maintenance:
-    uses: eclipse-score/cicd-workflows/.github/workflows/daily.yml@8d80e8df150cae21d53cbc8031d0f970648f7a67 # v0.0.3
+    uses: eclipse-score/cicd-workflows/.github/workflows/daily.yml@cache

--- a/.github/workflows/downstream_compatibility.yml
+++ b/.github/workflows/downstream_compatibility.yml
@@ -15,12 +15,26 @@ name: Downstream Compatibility
 on:
   workflow_call:
   pull_request:
+    # Parallel to review
     types: [opened, reopened, synchronize]
   merge_group:
+    # Post-review, pre-merge
     types: [checks_requested]
+  push:
+    # Update cache
+    branches:
+      - main
+  schedule:
+    # Update cache
+    # Runs every day at midnight UTC
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+  actions: write # cleanup old caches
 
 jobs:
-  test:
+  downstream-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/downstream_compatibility.yml
+++ b/.github/workflows/downstream_compatibility.yml
@@ -71,13 +71,17 @@ jobs:
           packages: graphviz
           cache: false
 
+      - name: Checkout PR
+        uses: actions/checkout@v7
+
       - name: Setup Bazel with shared caching
         uses: eclipse-score/cicd-actions/setup-bazel-cache@cache
         with:
-          disk-cache-key: ${{ github.job }}
-
-      - name: Checkout PR
-        uses: actions/checkout@v7
+          # Matrix jobs need separate disk-cache archives because GitHub Actions
+          # cannot merge archives written concurrently under one cache key.
+          disk-cache-key: ${{ github.job }}-${{ matrix.consumer }}
+          # Keep the shared repository cache consistent by assigning one writer.
+          repository-cache-save: ${{ matrix.consumer == 'score and remote' && 'auto' || 'false' }}
 
       - name: Prepare Python
         run: bazel run //:ide_support

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  actions: write # cleanup old caches
 
 jobs:
   common:
@@ -34,6 +33,9 @@ jobs:
 
   tests:
     uses: ./.github/workflows/_test.yml
+    permissions:
+      contents: read
+      actions: write # cleanup old caches
 
   docs-build:
     needs: [tests]

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -24,20 +24,20 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  actions: write # cleanup old caches
+
 jobs:
   common:
-    uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@88cb460c47cb49efeb25cd7b73c8945dd1c5bce2 # on-pr/v0.0.0
-    permissions:
-      contents: read
+    uses: eclipse-score/cicd-workflows/.github/workflows/on-pr.yml@cache
 
   tests:
     uses: ./.github/workflows/_test.yml
 
   docs-build:
     needs: [tests]
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@37eaadadfefc263d94a858d25665735659e916fa
-    permissions:
-      contents: read
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@cache
     with:
       bazel-target: "//:docs"
       tests-report-artifact: tests-report


### PR DESCRIPTION
try using the workflows based on the new setup-bazel-cache action

They are intentionally unpinned